### PR TITLE
Rendering: first working version with fixed viewport canvas

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -35,7 +35,7 @@ export const RecogitoJS = (container: HTMLElement, options: TextAnnotatorOptions
   const setPresenceProvider = (provider: PresenceProvider) => {
     if (provider) {
       highlightLayer.setPainter(createPainter(provider, options.presence));
-      provider.on('selectionChange', () => highlightLayer.redraw(false));
+      provider.on('selectionChange', () => highlightLayer.redraw());
     }
   }
 

--- a/packages/text-annotator/src/highlight/highlightLayer.css
+++ b/packages/text-annotator/src/highlight/highlightLayer.css
@@ -1,3 +1,7 @@
+body {
+  overscroll-behavior-y: none;
+}
+
 .r6o-annotatable, .r6o-annotatable * {
   position: relative;
 }
@@ -7,10 +11,10 @@
 }
 
 .r6o-highlight-layer {
-  height: 100%;
+  height: 100vh;
   left: 0;
-  position: absolute;
+  position: fixed;
   top: 0;
   pointer-events: none;
-  width: 100%;
+  width: 100vw;
 }


### PR DESCRIPTION
### In this PR

This PR changes the way overlay rendering works. 

#### Problem

Previously, there was one large CANVAS, with equal size as the content element underneath. It turns out that canvas drawing performance reduces __significantly__ the larger the canvas gets. As a consequence, drawing was extremely sluggish for large texts.

#### Solution

This PR changes the architecture. Now, there is a fixed-position CANVAS, sized according to the size of the current browser viewport. Annotations are redrawn on scroll, thus keeping in sync with the current scroll state of the content area.