### PR TITLE
Firefox ponyfill

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -83,7 +83,10 @@ export const SelectionHandler = (container: HTMLElement, state: TextAnnotatorSta
         ranges[0].startContainer.nodeType === Node.TEXT_NODE &&
         ranges[0].endContainer.nodeType === Node.TEXT_NODE;
 
-      if (isValid) {
+      const hasChanged =
+        ranges[0].toString() !== currentTarget.selector?.range?.toString();
+
+      if (isValid && hasChanged) {
         currentTarget = {
           ...currentTarget,
           selector: rangeToSelector(ranges[0], container)

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -1,7 +1,7 @@
 import { Origin, type User } from '@annotorious/core';
 import { v4 as uuidv4 } from 'uuid';
 import type { TextAnnotatorState } from './state';
-import type { TextSelector, TextAnnotationTarget } from './model';
+import type { TextSelector, TextAnnotationTarget, TextAnnotation } from './model';
 
 const clearNativeSelection = () => {
   if (window.getSelection) {
@@ -29,7 +29,6 @@ export const rangeToSelector = (range: Range, container: HTMLElement): TextSelec
   const end = start + quote.length;
 
   return {  quote, start, end, range };
-
 }
 
 export const SelectionHandler = (container: HTMLElement, state: TextAnnotatorState) => {
@@ -70,10 +69,10 @@ export const SelectionHandler = (container: HTMLElement, state: TextAnnotatorSta
     if (debounceTimer)
       clearTimeout(debounceTimer);
 
-    debounceTimer = setTimeout(() => onSelectionChange(evt), 50);
+    debounceTimer = setTimeout(() => onSelectionChange(), 50);
   });
 
-  const onSelectionChange = (evt: PointerEvent) => { 
+  const onSelectionChange = () => { 
     const sel = document.getSelection();
 
     if (!sel.isCollapsed && isLeftClick && currentTarget) {
@@ -126,9 +125,10 @@ export const SelectionHandler = (container: HTMLElement, state: TextAnnotatorSta
 
     setTimeout(() => {
       if (currentTarget?.selector) {
-        store.updateTarget(currentTarget, Origin.LOCAL);
+        store.updateTarget(currentTarget, Origin.LOCAL, true);
 
         selection.clickSelect(currentTarget.annotation, evt);
+
         currentTarget = null;
         lastPointerEvent = undefined;
       } else {            

--- a/packages/text-annotator/src/highlight/highlightLayer.ts
+++ b/packages/text-annotator/src/highlight/highlightLayer.ts
@@ -123,7 +123,7 @@ export const createHighlightLayer = (
     const { top, left, minX, minY, maxX, maxY } = getViewport();   
     
     const annotationsInView = store.getIntersectingRects(minX, minY, maxX, maxY);
-
+    
     const { width, height } = fgCanvas;
 
     // Get current selection

--- a/packages/text-annotator/src/state/TextAnnotationStore.ts
+++ b/packages/text-annotator/src/state/TextAnnotationStore.ts
@@ -1,5 +1,5 @@
-import type { Store } from '@annotorious/core';
-import type { TextAnnotation } from '../model';
+import type { Origin, Store } from '@annotorious/core';
+import type { TextAnnotation, TextAnnotationTarget } from '../model';
 
 export type TextAnnotationStore = Store<TextAnnotation> & {
 
@@ -12,6 +12,8 @@ export type TextAnnotationStore = Store<TextAnnotation> & {
   getIntersectingRects(minX: number, minY: number, maxX: number, maxY: number): AnnotationRects[];
   
   recalculatePositions(): void;
+
+  updateTarget(target: TextAnnotationTarget, origin?: Origin, firefoxInterop?: boolean): void;
 
 }
 

--- a/packages/text-annotator/src/state/TextAnnotatorState.ts
+++ b/packages/text-annotator/src/state/TextAnnotatorState.ts
@@ -67,11 +67,13 @@ export const createTextAnnotatorState = (
     }
   }
 
-  const updateTarget = (target: TextAnnotationTarget, origin = Origin.LOCAL) => {
+  const updateTarget = (target: TextAnnotationTarget, origin = Origin.LOCAL, firefoxInterop = false) => {
     const revived = target.selector.range instanceof Range ?
       target : reviveTarget(target, container);
 
     store.updateTarget(revived, origin);
+
+    tree.update(target, firefoxInterop);
   }
 
   const bulkUpdateTargets = (targets: TextAnnotationTarget[], origin = Origin.LOCAL) => {
@@ -142,9 +144,11 @@ export const createTextAnnotatorState = (
     if (deleted?.length > 0)
       deleted.forEach(a => tree.remove(a.target));
 
+    /*
     if (updated?.length > 0)
       updated.forEach(({ oldValue, newValue}) =>
         tree.update(oldValue.target, newValue.target));
+    */
   });
 
   return {
@@ -159,7 +163,7 @@ export const createTextAnnotatorState = (
       getIntersectingRects,
       recalculatePositions,
       updateTarget
-    },
+    } as TextAnnotationStore,
     selection,
     hover,
     viewport

--- a/packages/text-annotator/src/state/spatialTree.ts
+++ b/packages/text-annotator/src/state/spatialTree.ts
@@ -34,7 +34,8 @@ export const createSpatialTree = (store: Store<TextAnnotation>, container: HTMLE
   const toItems = (target: TextAnnotationTarget, firefoxInterop = false): IndexedHighlightRect[] => {
     const offset = container.getBoundingClientRect();
 
-    const rects = false ? 
+    // TODO we could change this to use the firefoxInterop flag!
+    const rects = true ? 
       getClientRectsPonyfill(target.selector.range) :
       Array.from(target.selector.range.getClientRects());
 

--- a/packages/text-annotator/src/utils/getClientRectsPonyfill.ts
+++ b/packages/text-annotator/src/utils/getClientRectsPonyfill.ts
@@ -1,0 +1,113 @@
+/**
+ * Wraps a DOM range CLEVERLY! If the range spans multiple
+ * elements, it's broken apart appropriately, and each segment
+ * is wrapped 
+ */
+const wrapRange = (range: Range) => {
+  const {
+    commonAncestorContainer,
+    startContainer,
+    startOffset,
+    endContainer,
+    endOffset
+  } = range;
+
+  const originalChildren = commonAncestorContainer.childNodes;
+
+  // Function to reverse the wrapping operation
+  const unwrap = () =>
+    (commonAncestorContainer as Element).replaceChildren(...originalChildren);
+
+  // Shorthand
+  const surround = (range: Range) => {
+    const wrapper = document.createElement('SPAN');
+    range.surroundContents(wrapper);
+    return wrapper;
+  };
+
+  if (startContainer === endContainer) {
+    // Trivial case
+    return { unwrap, nodes: [surround(range)] };
+  } else {
+    // Not-so-trivial case - we need to break the range 
+    // apart and create sub-ranges for each segment
+
+    // Start by wrapping text segments in start and end nodes
+    const startRange = document.createRange();
+    startRange.selectNodeContents(startContainer);
+    startRange.setStart(startContainer, startOffset);
+    const startNode = surround(startRange);
+
+    const endRange = document.createRange();
+    endRange.selectNode(endContainer);
+    endRange.setEnd(endContainer, endOffset);
+    const endNode = surround(endRange);
+
+    // And wrap nodes in between, if any
+    const textNodesBetween = getTextNodesBetween(range);
+
+    const innerNodes = textNodesBetween.reverse().map(node => {
+      const wrapper = document.createElement('SPAN');
+      node.parentNode.insertBefore(wrapper, node);
+      wrapper.appendChild(node);
+      return wrapper;
+    });
+
+    return { unwrap, nodes: [startNode, ...innerNodes, endNode] };
+  }
+
+}
+
+/**
+ * Returns a list of all text nodes between the start
+ * and end node of the range. Start and end node themselves 
+ * are NOT INCLUDED!
+ */
+const getTextNodesBetween = (range: Range): Node[] => {
+  const { 
+    commonAncestorContainer, 
+    startContainer, 
+    endContainer 
+  } = range;
+
+  const ni = document.createNodeIterator(commonAncestorContainer, NodeFilter.SHOW_TEXT);
+
+  let n = ni.nextNode();
+
+  let take = false;
+  
+  const nodesBetween: Node[] = [];
+
+  while (n != null) {
+    if (n === endContainer)
+      take = false;
+
+    if (take)
+      nodesBetween.push(n);
+
+    if (n === startContainer)
+      take = true;
+
+    n = ni.nextNode()
+  }
+
+  return nodesBetween;
+}
+
+export const getClientRectsPonyfill = (range: Range) => {
+  const { startContainer, endContainer } = range;
+
+  if (startContainer === endContainer) {
+    return Array.from(range.getClientRects());
+  } else {
+    const { unwrap, nodes } = wrapRange(range);
+
+    const rects = nodes.reduce((rects, node) => {
+      return [...rects, ...node.getClientRects()];
+    }, [] as DOMRect[]);
+  
+    unwrap();
+    
+    return rects;
+  }
+}

--- a/packages/text-annotator/src/utils/index.ts
+++ b/packages/text-annotator/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './mergeClientRects';
+export * from './getClientRectsPonyfill';


### PR DESCRIPTION
## In this PR

This PR fixes the open issue in PR #2: the SelectionHandler now creates accurate text selection highlights in Firefox. This is done via the following trick:

- The text selection is temporarily wrapped in SPANs. Wrapping is based on the code from Recogito v2, and takes into account DOM markup nesting structure - i.e. it can deal with selections that cross deeply nested markup.
- Instead of `range.getClientRects()` (which is broken on Firefox), the clientRects are taken from the SPANs instead
- After getting the SPANs, the wrapping is reverted by deleting all children of the range commonAncestor, and replacing them with __clones of the children created before the wrapping__.
- Note that the last step destroys the original range! Therefore the range is regenerated by re-pointed it to the cloned nodes that correspond to the original selection start and end. 

https://github.com/recogito/text-annotator-js/assets/470971/ccaf0a61-028d-437c-a941-2ba9abd835cc


