### PR TITLE
Implemented capturing of the `prefix` & `suffix` for the selector to match the `Text Quote Selector`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 dist
 node_modules
 **/config.json

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -1,24 +1,26 @@
 import { Origin, type User } from '@annotorious/core';
 import { v4 as uuidv4 } from 'uuid';
 import type { TextAnnotatorState } from './state';
-import type { TextSelector, TextAnnotationTarget, TextSelectorQuote } from './model';
+import type { TextSelector, TextAnnotationTarget, TextQuoteSelector } from './model';
 import { trimRange } from './utils';
 
-const rangeToQuote = (range: Range): TextSelectorQuote => {
+const rangeToQuoteSelector = (range: Range): TextQuoteSelector => {
+  const { startContainer, startOffset, endContainer, endOffset } = range;
+
   const snippetLength = 10;
 
   const rangePrefix = document.createRange();
-  rangePrefix.setStart(range.startContainer, Math.max(range.startOffset - snippetLength, 0));
-  rangePrefix.setEnd(range.startContainer, range.startOffset);
+  rangePrefix.setStart(startContainer, Math.max(startOffset - snippetLength, 0));
+  rangePrefix.setEnd(startContainer, startOffset);
 
   const rangeSuffix = document.createRange();
-  rangeSuffix.setStart(range.endContainer, range.endOffset);
-  rangeSuffix.setEnd(range.endContainer, Math.min(range.endOffset + snippetLength, range.endContainer.textContent.length));
+  rangeSuffix.setStart(endContainer, endOffset);
+  rangeSuffix.setEnd(endContainer, Math.min(endOffset + snippetLength, endContainer.textContent.length));
 
   return {
-    exact: range.toString(),
-    prefix: rangePrefix.toString(),
-    suffix: rangeSuffix.toString()
+    quote: range.toString(),
+    quotePrefix: rangePrefix.toString(),
+    quoteSuffix: rangeSuffix.toString()
   }
 }
 
@@ -32,13 +34,13 @@ export const rangeToSelector = (range: Range, container: HTMLElement, offsetRefe
   rangeBefore.setStart(offsetReference, 0);
   rangeBefore.setEnd(range.startContainer, range.startOffset);
 
-  const quote = rangeToQuote(range);
+  const quoteSelector = rangeToQuoteSelector(range);
   const start = rangeBefore.toString().length;
-  const end = start + quote.exact.length;
+  const end = start + quoteSelector.quote.length;
 
   return offsetReferenceSelector ?
-    { quote, start, end, range, offsetReference } :
-    { quote, start, end, range };
+    { ...quoteSelector, start, end, range, offsetReference } :
+    { ...quoteSelector, start, end, range };
 }
 
 export const SelectionHandler = (

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -5,10 +5,6 @@ import type { TextSelector, TextAnnotationTarget, TextSelectorQuote } from './mo
 import { trimRange } from './utils';
 
 const rangeToQuote = (range: Range): TextSelectorQuote => {
-  /**
-   * Captures the prefix and suffix snippets of the selection to match the `Text Quote Selector` spec
-   * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
-   */
   const snippetLength = 10;
 
   const rangePrefix = document.createRange();

--- a/packages/text-annotator/src/model/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/TextAnnotation.ts
@@ -14,7 +14,15 @@ export interface TextAnnotationTarget extends AnnotationTarget {
 
 export interface TextSelector {
 
-  quote: string;
+  /**
+   * Matches the `Text Quote Selector` spec from the W3C Annotation Data Model
+   * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
+   */
+  quote: {
+    exact: string;
+    prefix: string;
+    suffix: string;
+  }
   
   start: number;
 

--- a/packages/text-annotator/src/model/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/TextAnnotation.ts
@@ -14,15 +14,7 @@ export interface TextAnnotationTarget extends AnnotationTarget {
 
 export interface TextSelector {
 
-  /**
-   * Matches the `Text Quote Selector` spec from the W3C Annotation Data Model
-   * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
-   */
-  quote: {
-    exact: string;
-    prefix: string;
-    suffix: string;
-  }
+  quote: TextSelectorQuote
   
   start: number;
 
@@ -31,5 +23,19 @@ export interface TextSelector {
   range: Range;
 
   offsetReference?: HTMLElement
+
+}
+
+/**
+ * Matches the `Text Quote Selector` spec from the W3C Annotation Data Model
+ * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
+ */
+export interface TextSelectorQuote {
+
+  exact: string;
+
+  prefix: string;
+
+  suffix: string;
 
 }

--- a/packages/text-annotator/src/model/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/TextAnnotation.ts
@@ -12,10 +12,26 @@ export interface TextAnnotationTarget extends AnnotationTarget {
 
 }
 
-export interface TextSelector {
+/**
+ * Matches the `Text Quote Selector` spec
+ * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
+ */
+export interface TextQuoteSelector {
 
-  quote: TextSelectorQuote
-  
+  quote: string;
+
+  quotePrefix: string;
+
+  quoteSuffix: string;
+
+}
+
+/**
+ * Matches the `Text Position Selector` spec
+ * @see https://www.w3.org/TR/annotation-model/#text-position-selector
+ */
+export interface TextPositionSelector {
+
   start: number;
 
   end: number;
@@ -26,16 +42,5 @@ export interface TextSelector {
 
 }
 
-/**
- * Matches the `Text Quote Selector` spec from the W3C Annotation Data Model
- * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
- */
-export interface TextSelectorQuote {
+export type TextSelector = TextQuoteSelector & TextPositionSelector;
 
-  exact: string;
-
-  prefix: string;
-
-  suffix: string;
-
-}

--- a/packages/text-annotator/src/state/reviveTarget.ts
+++ b/packages/text-annotator/src/state/reviveTarget.ts
@@ -11,7 +11,7 @@ export const reviveTarget = (
   target: TextAnnotationTarget, 
   container: HTMLElement
 ): TextAnnotationTarget => {  
-  const { quote, start, end } = target.selector;
+  const { start, end } = target.selector;
 
   const offsetReference = target.selector.offsetReference ? target.selector.offsetReference : container;
   if (!offsetReference)
@@ -65,7 +65,6 @@ export const reviveTarget = (
     ...target,
     selector: { 
       ...target.selector,
-      quote, 
       start, 
       end, 
       range

--- a/packages/text-annotator/src/state/reviveTarget.ts
+++ b/packages/text-annotator/src/state/reviveTarget.ts
@@ -65,8 +65,6 @@ export const reviveTarget = (
     ...target,
     selector: { 
       ...target.selector,
-      start, 
-      end, 
       range
     }
   }


### PR DESCRIPTION
## Issue
This PR resolves the https://github.com/recogito/text-annotator-js/issues/4 issue

## Changes Made
In this PR I implemented capturing of the `prefix` & `suffix` properties to match the `Text Quote Selector` spec. For both of them I use the `Range` class that captures ±10 characters on the `start`/`endContainer` respectively. Then the textual content is simply extracted from the using the `.toString()`

## Refinement that can be made on demand
Another way to refine the `prefix`/`suffix` selection is to go to the `prev`/`nextSibling` when there are not enough characters to capture on `start`/`endContainer`. I started to work in that direction first but realized that it adds a serious complexity overhead, solving the edge case that hasn't blocked anyone yet 🤷🏻‍♂️ . So decided to go with a simpler approach for now 

## Demo

https://github.com/recogito/text-annotator-js/assets/68850090/0d0e3f77-0911-47a5-a95b-90033256c3c8

