### PR TITLE
Fixes/revisions to original PR#5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 dist
 node_modules
 **/config.json

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -1,52 +1,31 @@
 import { Origin, type User } from '@annotorious/core';
 import { v4 as uuidv4 } from 'uuid';
 import type { TextAnnotatorState } from './state';
-import type { TextSelector, TextAnnotationTarget, TextQuoteSelector } from './model';
+import type { TextSelector, TextAnnotationTarget } from './model';
 import { trimRange } from './utils';
 
-const rangeToQuoteSelector = (range: Range): TextQuoteSelector => {
-  const { startContainer, startOffset, endContainer, endOffset } = range;
-
-  const snippetLength = 10;
-
-  const rangePrefix = document.createRange();
-  rangePrefix.setStart(startContainer, Math.max(startOffset - snippetLength, 0));
-  rangePrefix.setEnd(startContainer, startOffset);
-
-  const rangeSuffix = document.createRange();
-  rangeSuffix.setStart(endContainer, endOffset);
-  rangeSuffix.setEnd(endContainer, Math.min(endOffset + snippetLength, endContainer.textContent.length));
-
-  return {
-    quote: range.toString(),
-    quotePrefix: rangePrefix.toString(),
-    quoteSuffix: rangeSuffix.toString()
-  }
-}
-
 export const rangeToSelector = (range: Range, container: HTMLElement, offsetReferenceSelector?: string): TextSelector => {
-  const offsetReference: HTMLElement = offsetReferenceSelector
-      ? (range.startContainer.parentElement as HTMLElement).closest(offsetReferenceSelector)
-      : container;
-
-  // Helper range from the start of the contentNode to the start of the selection
   const rangeBefore = document.createRange();
+
+  const offsetReference: HTMLElement = offsetReferenceSelector ? 
+    (range.startContainer.parentElement as HTMLElement).closest(offsetReferenceSelector) : container;
+
+  // A helper range from the start of the contentNode to the start of the selection
   rangeBefore.setStart(offsetReference, 0);
   rangeBefore.setEnd(range.startContainer, range.startOffset);
 
-  const quoteSelector = rangeToQuoteSelector(range);
+  const quote = range.toString();
   const start = rangeBefore.toString().length;
-  const end = start + quoteSelector.quote.length;
+  const end = start + quote.length;
 
   return offsetReferenceSelector ?
-    { ...quoteSelector, start, end, range, offsetReference } :
-    { ...quoteSelector, start, end, range };
+    { quote, start, end, range, offsetReference } :
+    { quote, start, end, range };
 }
 
 export const SelectionHandler = (
   container: HTMLElement,
   state: TextAnnotatorState,
-  // Experimental
   offsetReferenceSelector?: string
 ) => {
 

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -1,24 +1,26 @@
 import { Origin, type User } from '@annotorious/core';
 import { v4 as uuidv4 } from 'uuid';
 import type { TextAnnotatorState } from './state';
-import type { TextSelector, TextAnnotationTarget, TextSelectorQuote } from './model';
+import type { TextSelector, TextAnnotationTarget, TextQuoteSelector } from './model';
 import { trimRange } from './utils';
 
-const rangeToQuote = (range: Range): TextSelectorQuote => {
+const rangeToQuoteSelector = (range: Range): TextQuoteSelector => {
+  const { startContainer, startOffset, endContainer, endOffset } = range;
+
   const snippetLength = 10;
 
   const rangePrefix = document.createRange();
-  rangePrefix.setStart(range.startContainer, Math.max(range.startOffset - snippetLength, 0));
-  rangePrefix.setEnd(range.startContainer, range.startOffset);
+  rangePrefix.setStart(startContainer, Math.max(startOffset - snippetLength, 0));
+  rangePrefix.setEnd(startContainer, startOffset);
 
   const rangeSuffix = document.createRange();
-  rangeSuffix.setStart(range.endContainer, range.endOffset);
-  rangeSuffix.setEnd(range.endContainer, Math.min(range.endOffset + snippetLength, range.endContainer.textContent.length));
+  rangeSuffix.setStart(endContainer, endOffset);
+  rangeSuffix.setEnd(endContainer, Math.min(endOffset + snippetLength, endContainer.textContent.length));
 
   return {
-    exact: range.toString(),
-    prefix: rangePrefix.toString(),
-    suffix: rangeSuffix.toString()
+    quote: range.toString(),
+    quotePrefix: rangePrefix.toString(),
+    quoteSuffix: rangeSuffix.toString()
   }
 }
 
@@ -32,13 +34,13 @@ export const rangeToSelector = (range: Range, container: HTMLElement, offsetRefe
   rangeBefore.setStart(offsetReference, 0);
   rangeBefore.setEnd(range.startContainer, range.startOffset);
 
-  const quote = rangeToQuote(range);
+  const quoteSelector = rangeToQuoteSelector(range);
   const start = rangeBefore.toString().length;
-  const end = start + quote.exact.length;
+  const end = start + quoteSelector.quote.length;
 
   return offsetReferenceSelector ?
-    { quote, start, end, range, offsetReference } :
-    { quote, start, end, range };
+    { ...quoteSelector, start, end, range, offsetReference } :
+    { ...quoteSelector, start, end, range };
 }
 
 export const SelectionHandler = (

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -5,10 +5,6 @@ import type { TextSelector, TextAnnotationTarget, TextSelectorQuote } from './mo
 import { trimRange } from './utils';
 
 const rangeToQuote = (range: Range): TextSelectorQuote => {
-  /**
-   * Captures the prefix and suffix snippets of the selection to match the `Text Quote Selector` spec
-   * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
-   */
   const snippetLength = 10;
 
   const rangePrefix = document.createRange();

--- a/packages/text-annotator/src/model/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/TextAnnotation.ts
@@ -14,7 +14,15 @@ export interface TextAnnotationTarget extends AnnotationTarget {
 
 export interface TextSelector {
 
-  quote: string;
+  /**
+   * Matches the `Text Quote Selector` spec from the W3C Annotation Data Model
+   * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
+   */
+  quote: {
+    exact: string;
+    prefix: string;
+    suffix: string;
+  }
   
   start: number;
 

--- a/packages/text-annotator/src/model/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/TextAnnotation.ts
@@ -12,26 +12,10 @@ export interface TextAnnotationTarget extends AnnotationTarget {
 
 }
 
-/**
- * Matches the `Text Quote Selector` spec
- * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
- */
-export interface TextQuoteSelector {
+export interface TextSelector {
 
   quote: string;
-
-  quotePrefix: string;
-
-  quoteSuffix: string;
-
-}
-
-/**
- * Matches the `Text Position Selector` spec
- * @see https://www.w3.org/TR/annotation-model/#text-position-selector
- */
-export interface TextPositionSelector {
-
+  
   start: number;
 
   end: number;
@@ -41,6 +25,3 @@ export interface TextPositionSelector {
   offsetReference?: HTMLElement
 
 }
-
-export type TextSelector = TextQuoteSelector & TextPositionSelector;
-

--- a/packages/text-annotator/src/model/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/TextAnnotation.ts
@@ -14,15 +14,7 @@ export interface TextAnnotationTarget extends AnnotationTarget {
 
 export interface TextSelector {
 
-  /**
-   * Matches the `Text Quote Selector` spec from the W3C Annotation Data Model
-   * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
-   */
-  quote: {
-    exact: string;
-    prefix: string;
-    suffix: string;
-  }
+  quote: TextSelectorQuote
   
   start: number;
 
@@ -31,5 +23,19 @@ export interface TextSelector {
   range: Range;
 
   offsetReference?: HTMLElement
+
+}
+
+/**
+ * Matches the `Text Quote Selector` spec from the W3C Annotation Data Model
+ * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
+ */
+export interface TextSelectorQuote {
+
+  exact: string;
+
+  prefix: string;
+
+  suffix: string;
 
 }

--- a/packages/text-annotator/src/model/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/TextAnnotation.ts
@@ -12,10 +12,26 @@ export interface TextAnnotationTarget extends AnnotationTarget {
 
 }
 
-export interface TextSelector {
+/**
+ * Matches the `Text Quote Selector` spec
+ * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
+ */
+export interface TextQuoteSelector {
 
-  quote: TextSelectorQuote
-  
+  quote: string;
+
+  quotePrefix: string;
+
+  quoteSuffix: string;
+
+}
+
+/**
+ * Matches the `Text Position Selector` spec
+ * @see https://www.w3.org/TR/annotation-model/#text-position-selector
+ */
+export interface TextPositionSelector {
+
   start: number;
 
   end: number;
@@ -26,16 +42,5 @@ export interface TextSelector {
 
 }
 
-/**
- * Matches the `Text Quote Selector` spec from the W3C Annotation Data Model
- * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
- */
-export interface TextSelectorQuote {
+export type TextSelector = TextQuoteSelector & TextPositionSelector;
 
-  exact: string;
-
-  prefix: string;
-
-  suffix: string;
-
-}

--- a/packages/text-annotator/src/state/reviveTarget.ts
+++ b/packages/text-annotator/src/state/reviveTarget.ts
@@ -11,7 +11,7 @@ export const reviveTarget = (
   target: TextAnnotationTarget, 
   container: HTMLElement
 ): TextAnnotationTarget => {  
-  const { quote, start, end } = target.selector;
+  const { start, end } = target.selector;
 
   const offsetReference = target.selector.offsetReference ? target.selector.offsetReference : container;
   if (!offsetReference)
@@ -65,7 +65,6 @@ export const reviveTarget = (
     ...target,
     selector: { 
       ...target.selector,
-      quote, 
       start, 
       end, 
       range

--- a/packages/text-annotator/src/state/reviveTarget.ts
+++ b/packages/text-annotator/src/state/reviveTarget.ts
@@ -65,8 +65,6 @@ export const reviveTarget = (
     ...target,
     selector: { 
       ...target.selector,
-      start, 
-      end, 
       range
     }
   }

--- a/packages/text-annotator/src/utils/getContext.ts
+++ b/packages/text-annotator/src/utils/getContext.ts
@@ -1,0 +1,31 @@
+export const getContext = (
+  range: Range, 
+  container: HTMLElement, 
+  length = 10,
+  offsetReferenceSelector?: string
+) => {
+  const offsetReference: HTMLElement = offsetReferenceSelector
+    ? (range.startContainer.parentElement as HTMLElement).closest(offsetReferenceSelector)
+    : container;
+
+  const rangeBefore = document.createRange();
+  rangeBefore.setStart(offsetReference, 0);
+  rangeBefore.setEnd(range.startContainer, range.startOffset);
+
+  const before = rangeBefore.toString();
+  
+  const rangeAfter = document.createRange();
+  rangeAfter.setStart(range.endContainer, range.endOffset);
+
+  if (offsetReference === document.body)
+    rangeAfter.setEnd(offsetReference, offsetReference.childNodes.length);
+  else
+    rangeAfter.setEndAfter(offsetReference);
+
+  const after = rangeAfter.toString();
+
+  return {
+    prefix: before.substring(before.length - length),
+    suffix: after.substring(0, length)
+  }
+}


### PR DESCRIPTION
## In this PR

This PR makes some revisions to the original PR #5, which aims to add support for `prefix` and `suffix` values in the text selector.

Note that this PR __keeps prefix and suffix out of the core model.__ They will be tied in only at the level of the W3CFormatAdapter, which is coming up in another PR.