### PR TITLE
Added `types` definition into `exports`

### DIFF
--- a/packages/extension-tei/package.json
+++ b/packages/extension-tei/package.json
@@ -19,6 +19,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/text-annotator-tei.es.js",
       "require": "./dist/text-annotator-tei.umd.js"
     },

--- a/packages/text-annotator/package.json
+++ b/packages/text-annotator/package.json
@@ -19,6 +19,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/text-annotator.es.js",
       "require": "./dist/text-annotator.umd.js"
     },


### PR DESCRIPTION
## Issue
When I started using the `@recogito/react-text-annotator` dependency in the project with the `Yarn v.1.22.19` & `Node v.20` I was hella surprised that none of the types from the `@recogito/text-annotator` were processed by the Typescript:
<img width="1378" alt="image" src="https://github.com/recogito/text-annotator-js/assets/68850090/d8ddb0a9-5cc6-48f7-94b7-00e10313519f">
Also, no proper hits were provided for the `TextAnnotator` component: 
![image](https://github.com/recogito/text-annotator-js/assets/68850090/9a5bcd6a-7682-4933-8b23-35e05d9d20b3)
Although IDE could navigate through the definition files they definitively were present in the `node_modules` 🤔 

## Changes made
The issue I found was that the `@recogito/text-annotator` didn't have the `types` property specified within the `exports` like in the `@recogito/react-text-annotator`: https://github.com/recogito/text-annotator-js/blob/1df4dd1123d637aa244070dea01ea1023b863951/packages/text-annotator-react/package.json#L17-L21
After I added it - everything started to work as intended, including automatic code suggestions ✅ 
<img width="715" alt="image" src="https://github.com/recogito/text-annotator-js/assets/68850090/7ebd351b-e9e6-4557-ab06-31b521437419">


I suppose that with such a Yarn + Node combination, the `exports` prop takes precedence over the top-level `main` & `types`...