### PR TITLE
Added style props types for the `TextAnnotation`

### DIFF
--- a/packages/text-annotator/src/model/core/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/core/TextAnnotation.ts
@@ -10,6 +10,8 @@ export interface TextAnnotationTarget extends AnnotationTarget {
 
   selector: TextSelector;
 
+  styleClass?: string;
+
 }
 
 export interface TextSelector {

--- a/packages/text-annotator/src/model/w3c/W3CTextAnnotation.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextAnnotation.ts
@@ -4,11 +4,15 @@ export interface W3CTextAnnotation extends W3CAnnotation {
 
   target: W3CTextAnnotationTarget | W3CTextAnnotationTarget[];
 
+  stylesheet?: W3CAnnotationStylesheet;
+
 }
 
 export interface W3CTextAnnotationTarget extends W3CAnnotationTarget {
 
   selector: W3CTextSelector | W3CTextSelector[];
+
+  styleClass?: string;
 
 }
 
@@ -43,3 +47,8 @@ export interface W3CTextPositionSelector {
 }
 
 export type W3CTextSelector = W3CTextQuoteSelector | W3CTextPositionSelector;
+
+export type W3CAnnotationStylesheet = string | {
+  type: 'CssStylesheet',
+  value: string
+}


### PR DESCRIPTION
In our use-case, we would like to choose different colors for the highlights made by a user. And the [`styleClass` fits](https://www.w3.org/TR/annotation-model/#styles) it perfectly. We can apply a class to the annotation on creation. And  then process it in the `TextAnnotator` `style` callback (roughly) like this:
https://github.com/recogito/text-annotator-js/blob/8bb8af986bd90e730c22f13bcd20e83060573b7e/packages/text-annotator/src/TextAnnotatorOptions.ts#L15
```ts
const annotationsStyle = (annotation: TextAnnotation): DrawingStyle => {
	if (annotation.target.styleClass === 'highlight-1') {
		return {
			fill: theme.annotations....
			fillOpacity: 0.2
		};
	} else {
	}
};
```