### PR TITLE
Added `destroy` method for the `TextAnnotator`

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -1,10 +1,9 @@
 import { ReactNode, useContext, useEffect, useRef } from 'react';
 import { AnnotoriousContext, DrawingStyle, Filter } from '@annotorious/react';
-import { createTextAnnotator } from '@recogito/text-annotator';
 import type { TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
+import { createTextAnnotator } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';
-import { textAnnotation } from '@recogito/text-annotator/dist/test/model/w3c/fixtures';
 
 export type TextAnnotatorProps<E extends unknown> = TextAnnotatorOptions<E> & {
 

--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -4,6 +4,7 @@ import { createTextAnnotator } from '@recogito/text-annotator';
 import type { TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';
+import { textAnnotation } from '@recogito/text-annotator/dist/test/model/w3c/fixtures';
 
 export type TextAnnotatorProps<E extends unknown> = TextAnnotatorOptions<E> & {
 
@@ -22,28 +23,28 @@ export const TextAnnotator = <E extends unknown>(props: TextAnnotatorProps<E>) =
   const { children, ...opts } = props;
 
   const { anno, setAnno } = useContext(AnnotoriousContext);
-  
-  useEffect(() => {  
-    if (setAnno) {
-      const anno = createTextAnnotator(el.current, opts);
-      anno.setStyle(props.style);
-      setAnno(anno);
-    }
+
+  useEffect(() => {
+    if (!setAnno) return;
+
+    const anno = createTextAnnotator(el.current, opts);
+    anno.setStyle(props.style);
+    setAnno(anno);
+
+    return () => anno.destroy();
   }, [setAnno]);
 
   useEffect(() => {
-    if (!anno)
-      return;
-    
+    if (!anno) return;
+
     anno.setStyle(props.style);
-  }, [props.style]);
+  }, [anno, props.style]);
 
   useEffect(() => {
-    if (!anno)
-      return;
+    if (!anno) return;
     
     anno.setFilter(props.filter);
-  }, [props.filter]);
+  }, [anno, props.filter]);
 
   return (
     <div ref={el}>

--- a/packages/text-annotator-react/test/index.tsx
+++ b/packages/text-annotator-react/test/index.tsx
@@ -1,7 +1,10 @@
-import React, { createRoot } from 'react-dom/client';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
 import { App } from './App';
 
-const root = createRoot(document.getElementById('root') as Element);
-root.render(
-  <App />
-)
+ReactDOM.createRoot(document.getElementById('root')!).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>
+);

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -2,7 +2,7 @@ import { Origin, type User } from '@annotorious/core';
 import { v4 as uuidv4 } from 'uuid';
 import type { TextAnnotatorState } from './state';
 import type { TextSelector, TextAnnotationTarget } from './model';
-import { trimRange } from './utils';
+import { debounce, trimRange } from './utils';
 
 export const rangeToSelector = (range: Range, container: HTMLElement, offsetReferenceSelector?: string): TextSelector => {
   const rangeBefore = document.createRange();
@@ -63,9 +63,7 @@ export const SelectionHandler = (
 
   container.addEventListener('selectstart', onSelectStart);
 
-  let debounceTimer: ReturnType<typeof setTimeout> = undefined;
-
-  const onSelectionChange = (evt: PointerEvent) => {
+  const onSelectionChange = debounce( (evt: PointerEvent) => {
     const sel = document.getSelection();
 
     // Chrome/iOS does not reliably fire the 'selectstart' event!
@@ -101,14 +99,9 @@ export const SelectionHandler = (
         }
       }
     }
-  }
+  })
 
-  document.addEventListener('selectionchange', (evt: PointerEvent) => {
-    if (debounceTimer)
-      clearTimeout(debounceTimer);
-
-    debounceTimer = setTimeout(() => onSelectionChange(evt), 10);
-  });
+  document.addEventListener('selectionchange', onSelectionChange);
 
   // Select events don't carry information about the mouse button
   // Therefore, to prevent right-click selection, we need to listen

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -106,15 +106,17 @@ export const SelectionHandler = (
   // Select events don't carry information about the mouse button
   // Therefore, to prevent right-click selection, we need to listen
   // to the initial pointerdown event and remember the button
-  container.addEventListener('pointerdown', (evt: PointerEvent) => {
+  const onPointerDown = (evt: PointerEvent) => {
     // Note that the event itself can be ephemeral!
     const { target, timeStamp, offsetX, offsetY, type } = evt;
     lastPointerDown = { ...evt, target, timeStamp, offsetX, offsetY, type };
-    
-    isLeftClick = evt.button === 0;
-  });
 
-  document.addEventListener('pointerup', (evt: PointerEvent) => {
+    isLeftClick = evt.button === 0;
+  }
+
+  container.addEventListener('pointerdown', onPointerDown);
+
+  const onPointerUp = (evt: PointerEvent) => {
     const annotatable = !(evt.target as Node).parentElement?.closest('.not-annotatable');
     if (!annotatable || !isLeftClick)
       return;
@@ -143,9 +145,19 @@ export const SelectionHandler = (
     } else {
       selection.clickSelect(currentTarget.annotation, evt);
     }
-  });
+  }
+
+  document.addEventListener('pointerup', onPointerUp);
+
+  const destroy = () => {
+    container.removeEventListener('selectstart', onSelectStart);
+    document.removeEventListener('selectionchange', onSelectionChange);
+    container.removeEventListener('pointerdown', onPointerDown);
+    document.removeEventListener('pointerup', onPointerUp);
+  }
 
   return {
+    destroy,
     setUser
   }
 

--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -85,7 +85,7 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
 
   const destroy = () => {
     highlightLayer.destroy();
-    // selectionHandler.destroy();
+    selectionHandler.destroy();
 
     // Other cleanup actions
     undoStack.destroy();

--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -84,7 +84,11 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
   }
 
   const destroy = () => {
-    throw 'Not implemented yet';
+    highlightLayer.destroy();
+    // selectionHandler.destroy();
+
+    // Other cleanup actions
+    undoStack.destroy();
   }
 
   return {

--- a/packages/text-annotator/src/highlight/highlightLayer.ts
+++ b/packages/text-annotator/src/highlight/highlightLayer.ts
@@ -3,15 +3,7 @@ import type { TextAnnotation } from '../model';
 import type { TextAnnotatorState } from '../state';
 import { defaultPainter, type HighlightPainter } from './HighlightPainter';
 import { trackViewport } from './trackViewport';
-
-const debounce = <T extends (...args: any[]) => void>(func: T, delay: number = 10): T => {
-  let timeoutId: ReturnType<typeof setTimeout>;
-
-  return ((...args: any[]) => {
-    clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => func.apply(this, args), delay);
-  }) as T;
-}
+import { debounce } from '../utils';
 
 const createCanvas = (className: string, highres?: boolean) => {
   const canvas = document.createElement('canvas');
@@ -177,7 +169,7 @@ export const createHighlightLayer = (
 
   // Redraw on DOM mutation
   // Options for the observer (which mutations to observe)
-  const config = { attributes: true, childList: true, subtree: true };
+  const config = { childList: true, subtree: true };
 
   // This is an extra precaution. The position of the container
   // might shift (without resizing) due to layout changes higher-up

--- a/packages/text-annotator/src/highlight/highlightLayer.ts
+++ b/packages/text-annotator/src/highlight/highlightLayer.ts
@@ -169,7 +169,7 @@ export const createHighlightLayer = (
 
   // Redraw on DOM mutation
   // Options for the observer (which mutations to observe)
-  const config = { childList: true, subtree: true };
+  const config: MutationObserverInit = { attributes: true, childList: true, subtree: true };
 
   // This is an extra precaution. The position of the container
   // might shift (without resizing) due to layout changes higher-up

--- a/packages/text-annotator/src/utils/debounce.ts
+++ b/packages/text-annotator/src/utils/debounce.ts
@@ -1,0 +1,8 @@
+export const debounce = <T extends (...args: any[]) => void>(func: T, delay = 10): T => {
+	let timeoutId: ReturnType<typeof setTimeout>;
+
+	return ((...args: any[]) => {
+		clearTimeout(timeoutId);
+		timeoutId = setTimeout(() => func.apply(this, args), delay);
+	}) as T;
+}

--- a/packages/text-annotator/src/utils/index.ts
+++ b/packages/text-annotator/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './getClientRectsPonyfill';
 export * from './getQuoteContext';
 export * from './mergeClientRects';
 export * from './trimRange';
+export * from './debounce';


### PR DESCRIPTION
## Issue
See - https://github.com/recogito/text-annotator-js/pull/20#issuecomment-1908416217

## Changes made
In this PR I:
- Added `destroy` method for the `SelectionHandler`
- Added `destroy` method for the `TextAnnotator`
- Migrated React example to the `StrictMode`. It helped to validate that even on 2 `useEffect` invocations - only a single annotator instance stays active