### PR TITLE
Added range cloning before running `trimRange`

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -74,7 +74,7 @@ export const SelectionHandler = (
       const ranges = Array.from(Array(sel.rangeCount).keys())
         .map(idx => sel.getRangeAt(idx));
 
-      const trimmed = trimRange(ranges[0]);
+      const trimmed = trimRange(ranges[0].cloneRange());
 
       const hasChanged =
         trimmed.toString() !== currentTarget.selector?.quote;

--- a/packages/text-annotator/src/utils/trimRange.ts
+++ b/packages/text-annotator/src/utils/trimRange.ts
@@ -14,7 +14,7 @@ export const trimRange = (range: Range): Range => {
     // Get first text child in next container
     const nextText = nextContainer?.nodeType === Node.TEXT_NODE ?
       nextContainer :
-      Array.from(nextContainer!.childNodes).filter(n => n.nodeType === Node.TEXT_NODE).shift();   
+      Array.from(nextContainer!.childNodes).filter(n => n.nodeType === Node.TEXT_NODE).shift();
 
     range.setEnd(nextText!, 0);
   }
@@ -25,7 +25,7 @@ export const trimRange = (range: Range): Range => {
     // Get last text child in previous container
     const prevText = prevContainer?.nodeType === Node.TEXT_NODE ?
       prevContainer :
-      Array.from(prevContainer!.childNodes).filter(n => n.nodeType === Node.TEXT_NODE).pop();   
+      Array.from(prevContainer!.childNodes).filter(n => n.nodeType === Node.TEXT_NODE).pop();
 
     range.setEnd(prevText!, prevText?.textContent?.length || 0);
   }


### PR DESCRIPTION
## Issue
This PR resolves the issue https://github.com/recogito/text-annotator-js/issues/27

## Changes Made
I used the simpler approach from the suggested ones - just cloning the selection range to prevent mutation of the "live" selection range. It fixes the unexpected selection prevention after nested elements