### PR TITLE
Fixed rendering of the pre-defined annos for the `text-annotator` example page

### DIFF
--- a/packages/text-annotator/src/state/reviveTarget.ts
+++ b/packages/text-annotator/src/state/reviveTarget.ts
@@ -1,11 +1,12 @@
 import type { TextAnnotationTarget } from '../model';
 
 /**
- * Recalculates the DOM range from the given text annotation target.
- * 
- * @param annotation the text annotation
+ * Constructs a new target with the recalculated DOM range from the given text annotation target
+ *
+ * @param target the text annotation target
  * @param container the HTML container of the annotated content
- * @returns the DOM range
+ *
+ * @returns text annotation target
  */
 export const reviveTarget = (
   target: TextAnnotationTarget, 

--- a/packages/text-annotator/test/annotations.w3c.json
+++ b/packages/text-annotator/test/annotations.w3c.json
@@ -20,8 +20,8 @@
         },
         {
           "type": "TextPositionSelector",
-          "start": 725,
-          "end": 756
+          "start": 716,
+          "end": 747
         }
       ]
     }
@@ -47,8 +47,8 @@
         },
         {
           "type": "TextPositionSelector",
-          "start": 966,
-          "end": 1014
+          "start": 941,
+          "end": 989
         }
       ]
     }
@@ -68,14 +68,14 @@
       "selector": [
         {
           "type": "TextQuoteSelector",
-          "exact": "Now Neptune had gone off to the Ethiopians, who are at the world's end, and lie in two halves, the one looking\n        West and the other East. He had gone there to accept a",
+          "exact": "Now Neptune had gone off to the Ethiopians, who are at the world's end, and lie in two halves, the one looking West and the other East. He had gone there to accept a",
           "prefix": " \n        ",
           "suffix": " hecatomb "
         },
         {
           "type": "TextPositionSelector",
-          "start": 1336,
-          "end": 1509
+          "start": 1291,
+          "end": 1456
         }
       ]
     }

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -154,10 +154,14 @@
     </div>
 
     <script type="module">
-      import { createTextAnnotator } from '../src/index.ts';
+      import { createTextAnnotator, W3CTextFormat } from '../src/index.ts';
 
       window.onload = async () => {
-        const r = createTextAnnotator(document.getElementById('content'));
+        const contentContainer = document.getElementById('content');
+
+        const r = createTextAnnotator(contentContainer, {
+          adapter: W3CTextFormat('https://www.gutenberg.org', contentContainer)
+        });
 
         void r.loadAnnotations('annotations.w3c.json');
 
@@ -193,8 +197,8 @@
 
             filterActive = true;
           }
-        }
-      }
+        };
+      };
     </script>
   </body>
 </html>

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -181,22 +181,19 @@
           console.log('viewport', annotations);
         });
 
-        var filterActive = false;
-
-        document.getElementById('filter').addEventListener('click', () => {
+        let filterActive = false;
+        document.getElementById('filter').onclick = () => {
           if (filterActive) {
-            r.setFilter();
+            r.setFilter(undefined);
 
             filterActive = false;
           } else {
-            r.setFilter(annotation => {
-              // Dummy filter - just filter randomly
-              return  Math.random() < 0.5;
-            });
+            // Dummy filter - just filter randomly
+            r.setFilter(_annotation => Math.random() < 0.5);
 
             filterActive = true;
           }
-        });
+        }
       }
     </script>
   </body>

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -156,10 +156,10 @@
     <script type="module">
       import { createTextAnnotator } from '../src/index.ts';
 
-      window.onload = async function() {
-        var r = createTextAnnotator(document.getElementById('content'));
+      window.onload = async () => {
+        const r = createTextAnnotator(document.getElementById('content'));
 
-        r.loadAnnotations('annotations.json');
+        void r.loadAnnotations('annotations.w3c.json');
 
         r.on('createAnnotation', annotation => {
           console.log('createAnnotation', annotation);

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -186,16 +186,21 @@
         });
 
         let filterActive = false;
-        document.getElementById('filter').onclick = () => {
+        const toggleButton = document.getElementById('filter');
+        const toggleButtonLabel = toggleButton.innerText;
+
+        toggleButton.onclick = () => {
           if (filterActive) {
             r.setFilter(undefined);
 
             filterActive = false;
+            toggleButton.innerText = `${toggleButtonLabel} on`;
           } else {
             // Dummy filter - just filter randomly
             r.setFilter(_annotation => Math.random() < 0.5);
 
             filterActive = true;
+            toggleButton.innerText = `${toggleButtonLabel} off`;
           }
         };
       };

--- a/packages/text-annotator/tsconfig.json
+++ b/packages/text-annotator/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "allowJs": true,
     "checkJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Issue
When I was working with the `text-annotator` example page - I noticed that none of the pre-defined annotations were rendered on the page 👁️👁️👁️

## Changes made
1. Added usage of the `annotations.w3c.json` instead of the deleted `annotations.json` one
2. Added usage of the `W3CTextFormat` adapter to properly parse the new json
3. Fixed selectors positions according to the page content. I just re-selected the same quote and applied the positions reported in the `updateAnnotation` handler