### PR TITLE
Fixed non-inclusive `range` revival

### DIFF
--- a/packages/text-annotator/src/state/reviveTarget.ts
+++ b/packages/text-annotator/src/state/reviveTarget.ts
@@ -51,7 +51,7 @@ export const reviveTarget = (
   while (n !== null) {
     const len = n.textContent.length;
 
-    if (runningOffset + len > end) {
+    if (runningOffset + len >= end) {
       range.setEnd(n, end - runningOffset);
       break;
     }


### PR DESCRIPTION
## Issue
When the `selector` `end` position matches the end of the `text` node - the revived range ends on the next node's start
![image](https://github.com/recogito/text-annotator-js/assets/68850090/9ceca3df-90ae-4326-967d-ec48e4f06e10)

---

I noticed it while working on omitting the not annotable elements. There made the revive method iterator to skip them:
```ts
const iterator = document.createNodeIterator(offsetReference, NodeFilter.SHOW_TEXT, (node) =>
	node.parentElement?.closest(notAnnotableSelector)
		? NodeFilter.FILTER_SKIP
		: NodeFilter.FILTER_ACCEPT
);
```
So instead of ending on the not annotable element, the range was ending on the next annotable element. Leading to unexpected range positioning:
![image](https://github.com/recogito/text-annotator-js/assets/68850090/b4ce02b4-595a-4283-bc10-8252c2009d33)

## Changes Made
All the hurdle was caused by the non-inclusive comparison clause for the `end` position. It doesn't allow the range to capture a single `text` node parent