### PR TITLE
#41 Unified `style` prop with `isSelected` state argument

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useContext, useEffect, useRef } from 'react';
 import { AnnotoriousContext, Filter } from '@annotorious/react';
-import type { HighlightStyleOption, TextAnnotatorOptions } from '@recogito/text-annotator';
+import type { HighlightStyle, TextAnnotatorOptions } from '@recogito/text-annotator';
 import { createTextAnnotator } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';
@@ -11,7 +11,7 @@ export type TextAnnotatorProps<E extends unknown> = TextAnnotatorOptions<E> & {
 
   filter?: Filter;
 
-  style?: HighlightStyleOption;
+  style?: HighlightStyle;
 
 }
 

--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useContext, useEffect, useRef } from 'react';
-import { AnnotoriousContext, Filter } from '@annotorious/react';
-import type { HighlightStyle, TextAnnotatorOptions } from '@recogito/text-annotator';
+import { AnnotoriousContext, Filter, FormatAdapter } from '@annotorious/react';
+import type { HighlightStyle, TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
 import { createTextAnnotator } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';

--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -1,17 +1,17 @@
 import { ReactNode, useContext, useEffect, useRef } from 'react';
-import { AnnotoriousContext, DrawingStyle, Filter } from '@annotorious/react';
-import type { TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
+import { AnnotoriousContext, Filter } from '@annotorious/react';
+import type { HighlightStyleOption, TextAnnotatorOptions } from '@recogito/text-annotator';
 import { createTextAnnotator } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';
 
 export type TextAnnotatorProps<E extends unknown> = TextAnnotatorOptions<E> & {
 
-  children?: ReactNode | JSX.Element; 
+  children?: ReactNode | JSX.Element;
 
   filter?: Filter;
 
-  style?: DrawingStyle | ((annotation: TextAnnotation) => DrawingStyle);
+  style?: HighlightStyleOption;
 
 }
 

--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useContext, useEffect, useRef } from 'react';
 import { AnnotoriousContext, Filter, FormatAdapter } from '@annotorious/react';
-import type { HighlightStyle, TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
+import type { HighlightStyleExpression, TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
 import { createTextAnnotator } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';
@@ -13,7 +13,7 @@ export interface TextAnnotatorProps<E extends unknown> extends Omit<TextAnnotato
 
   filter?: Filter;
 
-  style?: HighlightStyle;
+  style?: HighlightStyleExpression;
 
 }
 

--- a/packages/text-annotator-react/src/tei/TEIAnnotator.tsx
+++ b/packages/text-annotator-react/src/tei/TEIAnnotator.tsx
@@ -1,8 +1,8 @@
-import { Children, ReactElement, ReactNode, cloneElement, useContext, useEffect } from 'react';
-import { AnnotoriousContext, DrawingStyle, Filter } from '@annotorious/react';
+import { Children, cloneElement, ReactElement, ReactNode, useContext, useEffect } from 'react';
+import { AnnotoriousContext, Filter } from '@annotorious/react';
 import { TEIPlugin } from '@recogito/text-annotator-tei';
+import type { TextAnnotatorOptions } from '@recogito/text-annotator';
 import { createTextAnnotator } from '@recogito/text-annotator';
-import type { TextAnnotatorOptions, TextAnnotation } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';
 
@@ -11,8 +11,6 @@ export type TEIAnnotatorProps = TextAnnotatorOptions & {
   children?: ReactNode | JSX.Element;
 
   filter?: Filter;
-
-  style?: DrawingStyle | ((annotation: TextAnnotation) => DrawingStyle);
 
 }
 

--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -1,6 +1,11 @@
-import { createAnonymousGuest, createLifecyleObserver, createBaseAnnotator, DrawingStyle, Filter, createUndoStack } from '@annotorious/core';
+import { createAnonymousGuest, createLifecyleObserver, createBaseAnnotator, Filter, createUndoStack } from '@annotorious/core';
 import type { Annotator, User, PresenceProvider } from '@annotorious/core';
-import { createCanvasHighlightRenderer, createCSSHighlightRenderer, createPresencePainter } from './highlight';
+import {
+  createCanvasHighlightRenderer,
+  createCSSHighlightRenderer,
+  createPresencePainter,
+  type HighlightStyle
+} from './highlight';
 import { scrollIntoView } from './api';
 import { TextAnnotationStore, TextAnnotatorState, createTextAnnotatorState } from './state';
 import type { TextAnnotation } from './model';
@@ -52,7 +57,7 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
       : createCanvasHighlightRenderer(container, state, viewport);
 
   if (opts.style)
-    highlightRenderer.setDrawingStyle(opts.style);
+    highlightRenderer.setHighlightStyle(opts.style);
 
   const selectionHandler = SelectionHandler(container, state, opts.offsetReferenceSelector);
 
@@ -70,8 +75,8 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
   const setFilter = (filter?: Filter) =>
     highlightRenderer.setFilter(filter);
 
-  const setStyle = (drawingStyle: DrawingStyle | ((annotation: TextAnnotation) => DrawingStyle) | undefined) =>
-    highlightRenderer.setDrawingStyle(drawingStyle);
+  const setStyle = (highlightStyle: HighlightStyle) =>
+    highlightRenderer.setHighlightStyle(highlightStyle);
 
   const setUser = (user: User) => {
     currentUser = user;

--- a/packages/text-annotator/src/TextAnnotatorOptions.ts
+++ b/packages/text-annotator/src/TextAnnotatorOptions.ts
@@ -1,6 +1,7 @@
-import type { DrawingStyle, FormatAdapter, PointerSelectAction } from '@annotorious/core';
+import type { FormatAdapter, PointerSelectAction } from '@annotorious/core';
 import type { PresencePainterOptions } from './presence';
 import type { TextAnnotation } from './model';
+import type { HighlightStyleOption } from './highlight/HighlightStyle';
 
 export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
 
@@ -14,6 +15,6 @@ export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
 
   presence?: PresencePainterOptions;
 
-  style?: DrawingStyle | ((annotation: TextAnnotation) => DrawingStyle);
-    
+  style?: HighlightStyleOption;
+
 }

--- a/packages/text-annotator/src/TextAnnotatorOptions.ts
+++ b/packages/text-annotator/src/TextAnnotatorOptions.ts
@@ -1,7 +1,7 @@
 import type { FormatAdapter, PointerSelectAction } from '@annotorious/core';
 import type { PresencePainterOptions } from './presence';
 import type { TextAnnotation } from './model';
-import type { HighlightStyleOption } from './highlight/HighlightStyle';
+import type { HighlightStyle } from './highlight';
 
 export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
 
@@ -15,6 +15,6 @@ export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
 
   presence?: PresencePainterOptions;
 
-  style?: HighlightStyleOption;
+  style?: HighlightStyle;
 
 }

--- a/packages/text-annotator/src/TextAnnotatorOptions.ts
+++ b/packages/text-annotator/src/TextAnnotatorOptions.ts
@@ -1,7 +1,7 @@
 import type { FormatAdapter, PointerSelectAction } from '@annotorious/core';
 import type { PresencePainterOptions } from './presence';
 import type { TextAnnotation } from './model';
-import type { HighlightStyle } from './highlight';
+import type { HighlightStyleExpression } from './highlight';
 
 export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
 
@@ -15,6 +15,6 @@ export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
 
   presence?: PresencePainterOptions;
 
-  style?: HighlightStyle;
+  style?: HighlightStyleExpression;
 
 }

--- a/packages/text-annotator/src/highlight/HighlightPainter.ts
+++ b/packages/text-annotator/src/highlight/HighlightPainter.ts
@@ -1,5 +1,5 @@
 import type { AnnotationRects } from '../state';
-import type { HighlightStyle } from './HighlightStyle';
+import type { HighlightDrawingStyle } from './HighlightStyle';
 import type { ViewportBounds } from './viewport';
 
 export interface HighlightPainter {
@@ -12,7 +12,7 @@ export interface HighlightPainter {
     annotation: AnnotationRects,
     viewportBounds: ViewportBounds,
     isSelected?: boolean
-  ): HighlightStyle;
+  ): HighlightDrawingStyle;
 
   reset(): void;
 

--- a/packages/text-annotator/src/highlight/HighlightPainter.ts
+++ b/packages/text-annotator/src/highlight/HighlightPainter.ts
@@ -1,5 +1,5 @@
 import type { AnnotationRects } from '../state';
-import type { HighlightDrawingStyle } from './HighlightStyle';
+import type { HighlightStyle } from './HighlightStyle';
 import type { ViewportBounds } from './viewport';
 
 export interface HighlightPainter {
@@ -12,7 +12,7 @@ export interface HighlightPainter {
     annotation: AnnotationRects,
     viewportBounds: ViewportBounds,
     isSelected?: boolean
-  ): HighlightDrawingStyle;
+  ): HighlightStyle;
 
   reset(): void;
 

--- a/packages/text-annotator/src/highlight/HighlightStyle.ts
+++ b/packages/text-annotator/src/highlight/HighlightStyle.ts
@@ -1,17 +1,17 @@
 import type { DrawingStyle } from '@annotorious/core';
 import type { TextAnnotation } from '../model';
 
-export const DEFAULT_STYLE: DrawingStyle = { 
+export const DEFAULT_STYLE: HighlightDrawingStyle = {
   fill: 'rgb(0, 128, 255)', 
   fillOpacity: 0.18 
 };
 
-export const DEFAULT_SELECTED_STYLE: DrawingStyle = { 
+export const DEFAULT_SELECTED_STYLE: HighlightDrawingStyle = {
   fill: 'rgb(0, 128, 255)', 
   fillOpacity: 0.45 
 };
 
-export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity'> {
+export interface HighlightDrawingStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity'> {
 
   underlineStyle?: string;
 
@@ -23,6 +23,7 @@ export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity
   
 }
 
-export type HighlightStyleOption =
-  HighlightStyle |
-  ((annotation: TextAnnotation, isSelected?: boolean) => HighlightStyle) | undefined;
+export type HighlightStyle =
+  | HighlightDrawingStyle
+  | ((annotation: TextAnnotation, isSelected?: boolean) => HighlightDrawingStyle)
+  | undefined;

--- a/packages/text-annotator/src/highlight/HighlightStyle.ts
+++ b/packages/text-annotator/src/highlight/HighlightStyle.ts
@@ -1,17 +1,17 @@
 import type { DrawingStyle } from '@annotorious/core';
 import type { TextAnnotation } from '../model';
 
-export const DEFAULT_STYLE: HighlightDrawingStyle = {
+export const DEFAULT_STYLE: HighlightStyle = {
   fill: 'rgb(0, 128, 255)', 
   fillOpacity: 0.18 
 };
 
-export const DEFAULT_SELECTED_STYLE: HighlightDrawingStyle = {
+export const DEFAULT_SELECTED_STYLE: HighlightStyle = {
   fill: 'rgb(0, 128, 255)', 
   fillOpacity: 0.45 
 };
 
-export interface HighlightDrawingStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity'> {
+export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity'> {
 
   underlineStyle?: string;
 
@@ -23,7 +23,7 @@ export interface HighlightDrawingStyle extends Pick<DrawingStyle, 'fill' | 'fill
   
 }
 
-export type HighlightStyle =
-  | HighlightDrawingStyle
-  | ((annotation: TextAnnotation, isSelected?: boolean) => HighlightDrawingStyle)
+export type HighlightStyleExpression =
+  | HighlightStyle
+  | ((annotation: TextAnnotation, isSelected?: boolean) => HighlightStyle)
   | undefined;

--- a/packages/text-annotator/src/highlight/HighlightStyle.ts
+++ b/packages/text-annotator/src/highlight/HighlightStyle.ts
@@ -1,4 +1,5 @@
 import type { DrawingStyle } from '@annotorious/core';
+import type { TextAnnotation } from '../model';
 
 export const DEFAULT_STYLE: DrawingStyle = { 
   fill: 'rgb(0, 128, 255)', 
@@ -21,3 +22,7 @@ export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity
   underlineThickness?: number;
   
 }
+
+export type HighlightStyleOption =
+  HighlightStyle |
+  ((annotation: TextAnnotation, isSelected?: boolean) => HighlightStyle) | undefined;

--- a/packages/text-annotator/src/highlight/canvas/highlightRenderer.ts
+++ b/packages/text-annotator/src/highlight/canvas/highlightRenderer.ts
@@ -1,9 +1,13 @@
-import type { DrawingStyle, Filter, ViewportState } from '@annotorious/core';
-import type { TextAnnotation } from '../../model';
+import type { Filter, ViewportState } from '@annotorious/core';
 import type { TextAnnotatorState } from '../../state';
 import { getViewportBounds, trackViewport } from '../viewport';
 import { debounce } from '../../utils';
-import { DEFAULT_SELECTED_STYLE, DEFAULT_STYLE, type HighlightStyle } from '../HighlightStyle';
+import {
+  DEFAULT_SELECTED_STYLE,
+  DEFAULT_STYLE,
+  type HighlightDrawingStyle,
+  type HighlightStyle
+} from '../HighlightStyle';
 import type { HighlightPainter } from '../HighlightPainter';
 
 const createCanvas = () => {
@@ -33,7 +37,7 @@ export const createCanvasHighlightRenderer = (
 ) => {
   const { store, selection, hover } = state;
   
-  let currentStyle: DrawingStyle | ((annotation: TextAnnotation, selected?: boolean) => DrawingStyle) | undefined;
+  let currentStyle: HighlightStyle;
 
   let currentFilter: Filter | undefined;
 
@@ -92,7 +96,7 @@ export const createCanvasHighlightRenderer = (
     annotationsInView.forEach(h => {
       const isSelected = selectedIds.has(h.annotation.id);
 
-      const base: HighlightStyle = currentStyle 
+      const base: HighlightDrawingStyle = currentStyle
         ? typeof currentStyle === 'function' 
           ? currentStyle(h.annotation, isSelected) 
           : currentStyle 
@@ -120,7 +124,7 @@ export const createCanvasHighlightRenderer = (
     setTimeout(() => onDraw(annotationsInView.map(({ annotation }) => annotation)), 1);
   });  
 
-  const setDrawingStyle = (style: DrawingStyle | ((a: TextAnnotation, selected?: boolean) => DrawingStyle)) => {
+  const setHighlightStyle = (style: HighlightStyle) => {
     currentStyle = style;
     refresh();
   }
@@ -191,7 +195,7 @@ export const createCanvasHighlightRenderer = (
   return {
     destroy,
     refresh,
-    setDrawingStyle,
+    setHighlightStyle,
     setFilter,
     setPainter: (painter: HighlightPainter) => customPainter = painter
   }

--- a/packages/text-annotator/src/highlight/canvas/highlightRenderer.ts
+++ b/packages/text-annotator/src/highlight/canvas/highlightRenderer.ts
@@ -5,8 +5,8 @@ import { debounce } from '../../utils';
 import {
   DEFAULT_SELECTED_STYLE,
   DEFAULT_STYLE,
-  type HighlightDrawingStyle,
-  type HighlightStyle
+  type HighlightStyle,
+  type HighlightStyleExpression
 } from '../HighlightStyle';
 import type { HighlightPainter } from '../HighlightPainter';
 
@@ -37,7 +37,7 @@ export const createCanvasHighlightRenderer = (
 ) => {
   const { store, selection, hover } = state;
   
-  let currentStyle: HighlightStyle;
+  let currentStyle: HighlightStyleExpression;
 
   let currentFilter: Filter | undefined;
 
@@ -96,7 +96,7 @@ export const createCanvasHighlightRenderer = (
     annotationsInView.forEach(h => {
       const isSelected = selectedIds.has(h.annotation.id);
 
-      const base: HighlightDrawingStyle = currentStyle
+      const base: HighlightStyle = currentStyle
         ? typeof currentStyle === 'function' 
           ? currentStyle(h.annotation, isSelected) 
           : currentStyle 
@@ -124,7 +124,7 @@ export const createCanvasHighlightRenderer = (
     setTimeout(() => onDraw(annotationsInView.map(({ annotation }) => annotation)), 1);
   });  
 
-  const setHighlightStyle = (style: HighlightStyle) => {
+  const setHighlightStyle = (style: HighlightStyleExpression) => {
     currentStyle = style;
     refresh();
   }

--- a/packages/text-annotator/src/highlight/css/highlightRenderer.ts
+++ b/packages/text-annotator/src/highlight/css/highlightRenderer.ts
@@ -4,7 +4,7 @@ import { debounce } from '../../utils';
 import { getViewportBounds, trackViewport } from '../viewport';
 import type { HighlightPainter } from '../HighlightPainter';
 import { createHighlights } from './highlights';
-import type { HighlightStyle } from '../HighlightStyle';
+import type { HighlightStyleExpression } from '../HighlightStyle';
 
 export const createCSSHighlightRenderer = (
   container: HTMLElement, 
@@ -15,7 +15,7 @@ export const createCSSHighlightRenderer = (
 
   let customPainter: HighlightPainter;
 
-  let currentStyle: HighlightStyle;
+  let currentStyle: HighlightStyleExpression;
 
   let currentFilter: Filter | undefined;
 
@@ -67,7 +67,7 @@ export const createCSSHighlightRenderer = (
   }
 
   // Refresh when style changes
-  const setHighlightStyle = (style: HighlightStyle) => {
+  const setHighlightStyle = (style: HighlightStyleExpression) => {
     currentStyle = style;
     refresh();
   }

--- a/packages/text-annotator/src/highlight/css/highlightRenderer.ts
+++ b/packages/text-annotator/src/highlight/css/highlightRenderer.ts
@@ -1,10 +1,10 @@
-import type { DrawingStyle, Filter, ViewportState } from '@annotorious/core';
+import type {  Filter, ViewportState } from '@annotorious/core';
 import type { TextAnnotatorState } from '../../state';
-import type { TextAnnotation } from '../../model';
 import { debounce } from '../../utils';
 import { getViewportBounds, trackViewport } from '../viewport';
 import type { HighlightPainter } from '../HighlightPainter';
 import { createHighlights } from './highlights';
+import type { HighlightStyle } from '../HighlightStyle';
 
 export const createCSSHighlightRenderer = (
   container: HTMLElement, 
@@ -15,7 +15,7 @@ export const createCSSHighlightRenderer = (
 
   let customPainter: HighlightPainter;
 
-  let currentStyle: DrawingStyle | ((annotation: TextAnnotation, selected?: boolean) => DrawingStyle) | undefined;
+  let currentStyle: HighlightStyle;
 
   let currentFilter: Filter | undefined;
 
@@ -67,7 +67,7 @@ export const createCSSHighlightRenderer = (
   }
 
   // Refresh when style changes
-  const setDrawingStyle = (style: DrawingStyle | ((a: TextAnnotation, selected?: boolean) => DrawingStyle)) => {
+  const setHighlightStyle = (style: HighlightStyle) => {
     currentStyle = style;
     refresh();
   }
@@ -131,7 +131,7 @@ export const createCSSHighlightRenderer = (
   return {
     destroy,
     refresh,
-    setDrawingStyle,
+    setHighlightStyle,
     setFilter,
     setPainter
   }

--- a/packages/text-annotator/src/highlight/css/highlights.ts
+++ b/packages/text-annotator/src/highlight/css/highlights.ts
@@ -5,11 +5,11 @@ import type { ViewportBounds } from '../viewport';
 import {
   DEFAULT_SELECTED_STYLE,
   DEFAULT_STYLE,
-  type HighlightDrawingStyle,
-  type HighlightStyle
+  type HighlightStyle,
+  type HighlightStyleExpression
 } from '../HighlightStyle';
 
-const toCSS = (s: HighlightDrawingStyle) => {
+const toCSS = (s: HighlightStyle) => {
   const backgroundColor = colord(s.fill || DEFAULT_STYLE.fill).alpha(s.fillOpacity || DEFAULT_STYLE.fillOpacity).toHex();
   return `background-color: ${backgroundColor};`
 }
@@ -26,7 +26,7 @@ export const createHighlights = () => {
     highlights: AnnotationRects[], 
     viewportBounds: ViewportBounds,
     selected: string[], 
-    currentStyle: HighlightStyle
+    currentStyle: HighlightStyleExpression
   ) => {
     if (customPainter)
       customPainter.clear();

--- a/packages/text-annotator/src/highlight/css/highlights.ts
+++ b/packages/text-annotator/src/highlight/css/highlights.ts
@@ -1,12 +1,15 @@
-import type { DrawingStyle } from '@annotorious/core';
 import { colord } from 'colord';
-import type { TextAnnotation } from '../../model';
 import type { HighlightPainter } from '../HighlightPainter';
 import type { AnnotationRects } from 'src/state';
 import type { ViewportBounds } from '../viewport';
-import { DEFAULT_SELECTED_STYLE, DEFAULT_STYLE } from '../HighlightStyle';
+import {
+  DEFAULT_SELECTED_STYLE,
+  DEFAULT_STYLE,
+  type HighlightDrawingStyle,
+  type HighlightStyle
+} from '../HighlightStyle';
 
-const toCSS = (s: DrawingStyle) => {
+const toCSS = (s: HighlightDrawingStyle) => {
   const backgroundColor = colord(s.fill || DEFAULT_STYLE.fill).alpha(s.fillOpacity || DEFAULT_STYLE.fillOpacity).toHex();
   return `background-color: ${backgroundColor};`
 }
@@ -26,7 +29,7 @@ export const createHighlights = () => {
     highlights: AnnotationRects[], 
     viewportBounds: ViewportBounds,
     selected: string[], 
-    currentStyle: DrawingStyle | ((annotation: TextAnnotation, selected: boolean) => DrawingStyle)
+    currentStyle: HighlightStyle
   ) => {
     if (customPainter)
       customPainter.clear();

--- a/packages/text-annotator/src/highlight/index.ts
+++ b/packages/text-annotator/src/highlight/index.ts
@@ -1,2 +1,4 @@
+export * from './HighlightPainter';
+export * from './HighlightStyle';
 export * from './canvas';
 export * from './css';

--- a/packages/text-annotator/src/presence/PresencePainter.ts
+++ b/packages/text-annotator/src/presence/PresencePainter.ts
@@ -1,7 +1,6 @@
 import type { Color, PresenceProvider, PresentUser } from '@annotorious/core';
 import type { AnnotationRects } from '../state';
-import type { HighlightStyle } from '../highlight/HighlightStyle';
-import type { HighlightPainter } from '../highlight/HighlightPainter';
+import type { HighlightDrawingStyle, HighlightPainter } from '../highlight';
 import type { PresencePainterOptions } from 'src/presence';
 import type { ViewportBounds } from '../highlight/viewport';
 
@@ -58,7 +57,7 @@ export const createPresencePainter = (
     highlight: AnnotationRects, 
     viewportBounds: ViewportBounds,
     isSelected?: boolean
-  ): HighlightStyle | undefined => {
+  ): HighlightDrawingStyle | undefined => {
     if (opts.font)
       ctx.font = opts.font;
 

--- a/packages/text-annotator/src/presence/PresencePainter.ts
+++ b/packages/text-annotator/src/presence/PresencePainter.ts
@@ -1,6 +1,6 @@
 import type { Color, PresenceProvider, PresentUser } from '@annotorious/core';
 import type { AnnotationRects } from '../state';
-import type { HighlightDrawingStyle, HighlightPainter } from '../highlight';
+import type { HighlightStyle, HighlightPainter } from '../highlight';
 import type { PresencePainterOptions } from 'src/presence';
 import type { ViewportBounds } from '../highlight/viewport';
 
@@ -57,7 +57,7 @@ export const createPresencePainter = (
     highlight: AnnotationRects, 
     viewportBounds: ViewportBounds,
     isSelected?: boolean
-  ): HighlightDrawingStyle | undefined => {
+  ): HighlightStyle | undefined => {
     if (opts.font)
       ctx.font = opts.font;
 

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -285,7 +285,10 @@
 
         var r = createTextAnnotator(contentContainer, {
           adapter: W3CTextFormat('https://www.gutenberg.org', contentContainer),
-          experimentalCSSRenderer: true
+          experimentalCSSRenderer: true,
+          style: (anno) => {
+
+          }
         });
 
         var annotations;

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -285,10 +285,7 @@
 
         var r = createTextAnnotator(contentContainer, {
           adapter: W3CTextFormat('https://www.gutenberg.org', contentContainer),
-          experimentalCSSRenderer: true,
-          style: (anno) => {
-
-          }
+          experimentalCSSRenderer: true
         });
 
         var annotations;


### PR DESCRIPTION
## Issue
This PR resolves the #41 issue when the public types defined the `style` callback w/o providing a selection state as the 2nd argument.

## Changes Made
- Renamed `HighlightStyle` -> `HighlightDrawingStyle`. The `HighlightDrawingStyle` partially extends the A9S `DrawingStyle` and narrows it down to the text annotation needs. Therefore, it would be appropriate to express that connection in the name, IMHO
- Added a shared aggregated type with the `HighlightStyle` name:
```ts
export type HighlightStyle =
  | HighlightDrawingStyle
  | ((annotation: TextAnnotation, isSelected?: boolean) => HighlightDrawingStyle)
  | undefined;
```
It's a part of the public API that uses the newer `HighlightDrawingStyle` and also exposes the `isSelected` flag. Using that single type helps with deduping and adds an ability to extend the exposed state in a single place

## Further Changes
The single `isSelected` argument can be changed to a `state: { selected: boolean }` object. In that way, adding new flags would become much easier