### PR TITLE
Removed re-export of the `PresencePainter` from the `highlight/css/index.ts`

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -1,6 +1,7 @@
 import { createAnonymousGuest, createLifecyleObserver, createBaseAnnotator, DrawingStyle, Filter, createUndoStack } from '@annotorious/core';
 import type { Annotator, User, PresenceProvider } from '@annotorious/core';
-import { createCanvasHighlightRenderer, createCSSHighlightRenderer, createPresencePainter } from './highlight';
+import { createCanvasHighlightRenderer, createCSSHighlightRenderer } from './highlight';
+import { createPresencePainter } from './presence';
 import { scrollIntoView } from './api';
 import { TextAnnotationStore, TextAnnotatorState, createTextAnnotatorState } from './state';
 import type { TextAnnotation } from './model';

--- a/packages/text-annotator/src/highlight/css/index.ts
+++ b/packages/text-annotator/src/highlight/css/index.ts
@@ -1,2 +1,1 @@
-export * from './highlightRenderer';
-export * from '../../presence/presencePainter';
+export * from './highlightRenderer'

--- a/packages/text-annotator/src/presence/index.ts
+++ b/packages/text-annotator/src/presence/index.ts
@@ -1,2 +1,2 @@
-export * from './presencePainter';
+export * from './PresencePainter';
 export * from './PresencePainterOptions';


### PR DESCRIPTION
I'm wondering... Was the re-exporting of the `PresencePainter` file from the `highlight/css/index.ts` intended? 🤔 

I noticed that quirk when `tsc` threw such an exception on the type check:
```
// src/highlight/css/index.ts:2:15 - error TS1261: Already included file name 'src/presence/presencePainter.ts' differs from file name 'src/presence/PresencePainter.ts' only in casing.
//   The file is in the program because:
//     Imported via '../../presence/presencePainter' from file 'src/highlight/css/index.ts'
//     Imported via './presencePainter' from file 'src/presence/index.ts'
//     Matched by include pattern './src/**/*' in 'tsconfig.json'
// 
// 2 export * from '../../presence/presencePainter';
//                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I _suppose_ we should only need a single export of the `PresencePainter`... Right?..