### PR TITLE
#47 Added `state: TextAnnotatorState` explicit type for the annotator

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -17,6 +17,8 @@ export interface TextAnnotator<T extends unknown = TextAnnotation> extends Annot
   // Returns true if successful (or false if the annotation is not currently rendered)
   scrollIntoView(annotation: TextAnnotation): boolean;
 
+  state: TextAnnotatorState;
+
 }
 
 export const createTextAnnotator = <E extends unknown = TextAnnotation>(


### PR DESCRIPTION
## Issue
This PR resolves the [2nd issue described in](https://arc.net/l/quote/ulutqqdw) #47 

## Changes Made
I explicitly added the `state` prop to the `TextAnnotator` type. Therefore, the type of the `annotator.state.store` now is the `TextAnnotatorStore` instead of the inherited `Store<TextAnnotation>`