### PR TITLE
#49 Added persistence of the `target.id` property of the `W3CTextAnnotation` on parsing/serialization

### DIFF
--- a/packages/text-annotator/src/model/core/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/core/TextAnnotation.ts
@@ -14,6 +14,8 @@ export interface TextAnnotationTarget extends AnnotationTarget {
 
 export interface TextSelector {
 
+  id?: string;
+
   quote: string;
   
   start: number;

--- a/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
@@ -64,7 +64,7 @@ const parseW3CTextTargets = (annotation: W3CTextAnnotation, container: HTMLEleme
     }, {});
 
     if (isTextSelector(selector)) {
-      parsed.selector.push(selector);
+      parsed.selector.push({ id: w3cTarget.id, ...selector });
     } else {
       const missingTypes = [
         !selector.start ? 'TextPositionSelector' : undefined,
@@ -141,6 +141,7 @@ export const serializeW3CTextAnnotation = (
 
     return {
       ...targetRest,
+      id: s.id,
       source,
       selector: w3cSelectors
     };

--- a/packages/text-annotator/test/annotations.w3c.json
+++ b/packages/text-annotator/test/annotations.w3c.json
@@ -9,6 +9,7 @@
     },
     "created": "2024-01-05T13:19:14.716Z",
     "target": {
+      "id": "602e0698-6602-46b2-87bc-4085df9eb2bc",
       "annotation": "9b6aa528-660a-4551-8265-66f45c61acab",
       "source": "https://www.gutenberg.org/files/1727/1727-h/1727-h.htm",
       "selector": [
@@ -36,6 +37,7 @@
     },
     "created": "2024-01-05T13:22:51.102Z",
     "target": {
+      "id": "09fa5142-82f2-46ef-81f0-7f1d73cedd35",
       "annotation": "51b54efc-cd3c-4667-91ab-3b24acba9b39",
       "source": "https://www.gutenberg.org/files/1727/1727-h/1727-h.htm",
       "selector": [
@@ -63,6 +65,7 @@
     },
     "created": "2024-01-05T13:23:18.956Z",
     "target": {
+      "id": "09fa5142-82f2-46ef-81f0-7f1d73cedd35",
       "annotation": "45d77d69-b9c9-419e-b6f3-672222bb3a23",
       "source": "https://www.gutenberg.org/files/1727/1727-h/1727-h.htm",
       "selector": [


### PR DESCRIPTION
## Issue
This PR resolves the #49 issue and adds support for proper parsing/serialization of the W3C `target.id` using the next relation: 
| Internal | | W3C |
|--------|--------|--------|
| `target.selector[X].id` | ⇔ | `target[X].id` | 