### PR TITLE
Removed the unused `container` from the `parse` method of the `W3CTextFormat`

### DIFF
--- a/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
@@ -21,14 +21,14 @@ export const W3CTextFormat = (
   source: string,
   container: HTMLElement
 ): W3CTextFormatAdapter => ({
-  parse: (serialized) => parseW3CTextAnnotation(serialized, container),
+  parse: (serialized) => parseW3CTextAnnotation(serialized),
   serialize: (annotation) => serializeW3CTextAnnotation(annotation, source, container)
 });
 
 const isTextSelector = (selector: Partial<TextSelector>): selector is TextSelector =>
   selector.quote !== undefined && selector.start !== undefined && selector.end !== undefined;
 
-const parseW3CTextTargets = (annotation: W3CTextAnnotation, container: HTMLElement) => {
+const parseW3CTextTargets = (annotation: W3CTextAnnotation) => {
   const {
     id: annotationId,
     creator,
@@ -79,8 +79,7 @@ const parseW3CTextTargets = (annotation: W3CTextAnnotation, container: HTMLEleme
 };
 
 export const parseW3CTextAnnotation = (
-  annotation: W3CTextAnnotation,
-  container: HTMLElement
+  annotation: W3CTextAnnotation
 ): ParseResult<TextAnnotation> => {
   const annotationId = annotation.id || uuidv4();
 
@@ -93,7 +92,7 @@ export const parseW3CTextAnnotation = (
   } = annotation;
 
   const bodies = parseW3CBodies(body, annotationId);
-  const target = parseW3CTextTargets(annotation, container);
+  const target = parseW3CTextTargets(annotation);
 
   return 'error' in target
     ? { error: target.error }


### PR DESCRIPTION
## Changes Made
In this PR I removed the `container` argument from the `parseW3CTextAnnotation` method. It became unused after this commit: https://github.com/recogito/text-annotator-js/commit/c2018d0426196e1cee2bbc12dfd7c7305be7a542