### PR TITLE
Fixed `W3CTextFormatAdapter` test execution

### DIFF
--- a/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
@@ -21,14 +21,14 @@ export const W3CTextFormat = (
   source: string,
   container: HTMLElement
 ): W3CTextFormatAdapter => ({
-  parse: (serialized) => parseW3CTextAnnotation(serialized, container),
+  parse: (serialized) => parseW3CTextAnnotation(serialized),
   serialize: (annotation) => serializeW3CTextAnnotation(annotation, source, container)
 });
 
 const isTextSelector = (selector: Partial<TextSelector>): selector is TextSelector =>
   selector.quote !== undefined && selector.start !== undefined && selector.end !== undefined;
 
-const parseW3CTextTargets = (annotation: W3CTextAnnotation, container: HTMLElement) => {
+const parseW3CTextTargets = (annotation: W3CTextAnnotation) => {
   const {
     id: annotationId,
     creator,
@@ -79,8 +79,7 @@ const parseW3CTextTargets = (annotation: W3CTextAnnotation, container: HTMLEleme
 };
 
 export const parseW3CTextAnnotation = (
-  annotation: W3CTextAnnotation,
-  container: HTMLElement
+  annotation: W3CTextAnnotation
 ): ParseResult<TextAnnotation> => {
   const annotationId = annotation.id || uuidv4();
 
@@ -93,7 +92,7 @@ export const parseW3CTextAnnotation = (
   } = annotation;
 
   const bodies = parseW3CBodies(body, annotationId);
-  const target = parseW3CTextTargets(annotation, container);
+  const target = parseW3CTextTargets(annotation);
 
   return 'error' in target
     ? { error: target.error }

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -21,10 +21,10 @@
         border-style: solid;
         border-color: #cfcfcf;
         border-width: 0 1px;
+      }
 
-        .not-annotatable {
-          background-color: wheat;
-        }
+      #content .not-annotatable {
+        background-color: wheat;
       }
 
       h1 {

--- a/packages/text-annotator/test/model/w3c/W3CTextFormatAdapter.test.ts
+++ b/packages/text-annotator/test/model/w3c/W3CTextFormatAdapter.test.ts
@@ -3,6 +3,7 @@ import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import { textAnnotation, incompleteTextAnnotation } from './fixtures';
 import {
   parseW3CTextAnnotation,
+  reviveSelector,
   serializeW3CTextAnnotation,
 } from '../../../src';
 
@@ -19,7 +20,7 @@ afterEach(() => {
 
 describe('parseW3CTextAnnotation', () => {
   it('should parse the sample annotation correctly', () => {
-    const { parsed, error } = parseW3CTextAnnotation(textAnnotation, global.contentContainer);
+    const { parsed, error } = parseW3CTextAnnotation(textAnnotation);
     expect(error).toBeUndefined();
 
     const fixtureBody = textAnnotation.body[0];
@@ -35,18 +36,18 @@ describe('parseW3CTextAnnotation', () => {
     expect(start).toStrictEqual(fixtureTarget.selector[1].start);
     expect(created.getTime()).toEqual(new Date(textAnnotation.created).getTime());
     expect(creator.id).toEqual(textAnnotation.creator.id);
-    expect(range).toBeDefined();
   });
 
   it('should return an error if the selector is incomplete', () => {
-    const { parsed, error } = parseW3CTextAnnotation(incompleteTextAnnotation, global.contentContainer);
+    const { parsed, error } = parseW3CTextAnnotation(incompleteTextAnnotation);
     expect(parsed).toBeUndefined();
     expect(error).toBeDefined();
     expect(error.message).toContain('Missing selector');
   });
 
   it('should serialize the sample annotation correctly', () => {
-    const { parsed, error } = parseW3CTextAnnotation(textAnnotation, global.contentContainer);
+    const { parsed, error } = parseW3CTextAnnotation(textAnnotation);
+    parsed.target.selector = parsed.target.selector.map(selector => reviveSelector(selector, global.contentContainer));
     expect(error).toBeUndefined();
 
     const serialized = serializeW3CTextAnnotation(parsed, textAnnotation.target[0].source, global.contentContainer);

--- a/packages/text-annotator/test/model/w3c/fixtures.ts
+++ b/packages/text-annotator/test/model/w3c/fixtures.ts
@@ -28,8 +28,8 @@ export const textAnnotation: W3CTextAnnotation = {
         },
         {
           type: 'TextPositionSelector',
-          start: 945,
-          end: 957
+          start: 986,
+          end: 998
         },
       ]
     }


### PR DESCRIPTION
## Issue
I noticed that the tests started failing after [this commit](https://github.com/recogito/text-annotator-js/commit/c2018d0426196e1cee2bbc12dfd7c7305be7a542), where the `reviveSelector` was removed from the parsing step.

## Changes Made
1. Adapted the tests to not expect that the `parseW3CTextAnnotation` will create selectors with the `range`
2. Adjusted selection ranges in the fixture of the current test page content
3. Fixed the non-standard CSS nesting on the test page

## Relations
This PR is based on the #55 PR changes
