### PR TITLE
Renamed `rangeToTEIRangeSelector` -> `textToTEISelector`

### DIFF
--- a/packages/extension-tei/src/crosswalk/forward.ts
+++ b/packages/extension-tei/src/crosswalk/forward.ts
@@ -84,7 +84,7 @@ const toTEIXPaths = (startPath: string[], endPath: string[], selectedRange: Rang
  * Using the DOM Range from a (revived!) TextSelector, this function computes
  * the TEIRangeSelector corresponding to that range.
  */
-export const selectorToTEIRangeSelector = (selector: TextSelector): TEIRangeSelector => {
+export const textToTEISelector = (selector: TextSelector): TEIRangeSelector => {
   const { range } = selector;
 
   // XPath segments for Range start and end nodes as a list
@@ -114,7 +114,7 @@ export const textToTEITarget =  (container: HTMLElement) => (t: TextAnnotationTa
   const target = reviveTarget(t, container);
   return {
     ...t,
-    selector: target.selector.map(selectorToTEIRangeSelector)
+    selector: target.selector.map(textToTEISelector)
   }
 }
 

--- a/packages/extension-tei/src/crosswalk/forward.ts
+++ b/packages/extension-tei/src/crosswalk/forward.ts
@@ -84,7 +84,7 @@ const toTEIXPaths = (startPath: string[], endPath: string[], selectedRange: Rang
  * Using the DOM Range from a (revived!) TextSelector, this function computes
  * the TEIRangeSelector corresponding to that range.
  */
-export const rangeToTEIRangeSelector = (selector: TextSelector): TEIRangeSelector => {
+export const selectorToTEIRangeSelector = (selector: TextSelector): TEIRangeSelector => {
   const { range } = selector;
 
   // XPath segments for Range start and end nodes as a list
@@ -114,7 +114,7 @@ export const textToTEITarget =  (container: HTMLElement) => (t: TextAnnotationTa
   const target = reviveTarget(t, container);
   return {
     ...t,
-    selector: target.selector.map(rangeToTEIRangeSelector)
+    selector: target.selector.map(selectorToTEIRangeSelector)
   }
 }
 


### PR DESCRIPTION
When I was working on the plugin for my app - I faced a need to transform the `TextSelector` to some custom selector type.
I noticed that `TEI` plugin also does that. But the name for the function is a bit unintuitive 🤔 
It's called `rangeToTEIRangeSelector` although it receives the `selector` and converts to a more specific selector. Shouldn't it be named `selectorToTEIRangeSelector`? 🤔 