### PR TITLE
#47 Added missing required `origin` for `addAnnotation` call

### DIFF
--- a/packages/extension-tei/src/crosswalk/forward.ts
+++ b/packages/extension-tei/src/crosswalk/forward.ts
@@ -110,7 +110,7 @@ export const rangeToTEIRangeSelector = (selector: TextSelector): TEIRangeSelecto
   };
 }
 
-export const textToTEITarget =  (container: HTMLElement) => (t: TextAnnotationTarget): TEIAnnotationTarget => {
+export const textToTEITarget = (container: HTMLElement) => (t: TextAnnotationTarget): TEIAnnotationTarget => {
   const target = reviveTarget(t, container);
   return {
     ...t,

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -74,7 +74,7 @@ export const SelectionHandler = (
         id: currentTarget.annotation,
         bodies: [],
         target: currentTarget
-      });
+      }, Origin.LOCAL);
 
       // Reminder: select events don't have offsetX/offsetY - reuse last up/down
       selection.clickSelect(currentTarget.annotation, lastPointerDown);


### PR DESCRIPTION
## Issue
After in #48 PR I added usage of the actual `TextAnnotatorStore` - the `store.addAnnotation` within the `SelectionHandler` started to fail. That's because the store defines the `origin` as a mandatory argument:

https://github.com/recogito/text-annotator-js/blob/3f587dd752084f3f6c291dec0577e01afb2d1e4d/packages/text-annotator/src/state/TextAnnotationStore.ts#L8