### PR TITLE
#47 Made `origin` optional for the `TextAnnotationStore` methods

### DIFF
--- a/packages/text-annotator/src/state/TextAnnotationStore.ts
+++ b/packages/text-annotator/src/state/TextAnnotationStore.ts
@@ -5,11 +5,11 @@ export interface TextAnnotationStore extends Omit<Store<TextAnnotation>, 'addAnn
 
   // Minor changes to default Annotorious store - text store returns feedback
   // on annotations that failed to render, to support lazy document loading scenarios
-  addAnnotation(annotation: TextAnnotation, origin: Origin): boolean;
+  addAnnotation(annotation: TextAnnotation, origin?: Origin): boolean;
 
-  bulkAddAnnotation(annotations: TextAnnotation[], replace: boolean, origin: Origin): TextAnnotation[];
+  bulkAddAnnotation(annotations: TextAnnotation[], replace: boolean, origin?: Origin): TextAnnotation[];
 
-  bulkUpsertAnnotations(annotations: TextAnnotation[], origin: Origin): TextAnnotation[];
+  bulkUpsertAnnotations(annotations: TextAnnotation[], origin?: Origin): TextAnnotation[];
 
   getAnnotationBounds(id: string, hintX?: number, hintY?: number, buffer?: number): DOMRect;
 


### PR DESCRIPTION
## Issue
After in #48 PR I added usage of the actual `TextAnnotatorStore` - the `store.addAnnotation` within the `SelectionHandler` started to fail. That's because the store defines the `origin` as a mandatory argument:
https://github.com/recogito/text-annotator-js/blob/3f587dd752084f3f6c291dec0577e01afb2d1e4d/packages/text-annotator/src/state/TextAnnotationStore.ts#L8

However, according to @rsimon, having a mandatory `origin` for the `TextAnnotatorStore` methods is redundant

Demo:
![image](https://github.com/recogito/text-annotator-js/assets/68850090/8af3f5c9-8185-4914-a5cf-30d8f2953d3e)
![image](https://github.com/recogito/text-annotator-js/assets/68850090/3d980008-2548-4698-8b62-49f55ad289ea)
