### PR TITLE
#68 Fixed capturing invisible annotations on "empty" nodes

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -2,7 +2,14 @@ import { Origin, type User } from '@annotorious/core';
 import { v4 as uuidv4 } from 'uuid';
 import type { TextAnnotatorState } from './state';
 import type { TextAnnotationTarget } from './model';
-import { debounce, splitAnnotatableRanges, rangeToSelector, trimRange, NOT_ANNOTATABLE_SELECTOR } from './utils';
+import {
+  debounce,
+  splitAnnotatableRanges,
+  rangeToSelector,
+  trimRange,
+  isWhitespaceOrEmpty,
+  NOT_ANNOTATABLE_SELECTOR
+} from './utils';
 
 export const SelectionHandler = (
   container: HTMLElement,
@@ -54,6 +61,8 @@ export const SelectionHandler = (
     if (sel.isCollapsed || !isLeftClick || !currentTarget) return;
 
     const selectionRange = sel.getRangeAt(0);
+    if (isWhitespaceOrEmpty(selectionRange)) return;
+
     const trimmedRange = trimRange(selectionRange.cloneRange())
     const annotatableRanges = splitAnnotatableRanges(trimmedRange);
 

--- a/packages/text-annotator/src/utils/index.ts
+++ b/packages/text-annotator/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './debounce';
 export * from './getAnnotatableFragment';
 export * from './getClientRectsPonyfill';
 export * from './getQuoteContext';
+export * from './isWhitespaceOrEmpty';
 export * from './isRevived';
 export * from './mergeClientRects';
 export * from './rangeToSelector';

--- a/packages/text-annotator/src/utils/isWhitespaceOrEmpty.ts
+++ b/packages/text-annotator/src/utils/isWhitespaceOrEmpty.ts
@@ -1,0 +1,3 @@
+export const whitespaceOrEmptyRegex = /^\s*$/;
+
+export const isWhitespaceOrEmpty = (range: Range): boolean => whitespaceOrEmptyRegex.test(range.toString())


### PR DESCRIPTION
## Issue
This PR resolves the #68 issue. Now the range won't be processed if it only consists of the whitespace characters or it's empty. It'll help to avoid the unnecessary creation of invisible annotations.
More details and examples can be found on the issue page - #68