### PR TITLE
Added `className` forwarding for the `TextAnnotator`

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -16,13 +16,15 @@ export interface TextAnnotatorProps<E extends unknown> extends Omit<TextAnnotato
 
   style?: DrawingStyle | ((annotation: TextAnnotation) => DrawingStyle);
 
+  className?: string;
+
 }
 
 export const TextAnnotator = <E extends unknown>(props: TextAnnotatorProps<E>) => {
 
   const el = useRef<HTMLDivElement>(null);
 
-  const { children, ...opts } = props;
+  const { className, children, ...opts } = props;
 
   const { anno, setAnno } = useContext(AnnotoriousContext);
 
@@ -50,7 +52,7 @@ export const TextAnnotator = <E extends unknown>(props: TextAnnotatorProps<E>) =
   }, [anno, props.filter]);
 
   return (
-    <div ref={el}>
+    <div ref={el} className={className}>
       {children}
     </div>
   )


### PR DESCRIPTION
## Issue
This PR helps to resolve the [#36 Highlights are not visible on elements with `background-color`](https://github.com/recogito/text-annotator-js/issues/36#top) issue for any custom apps that use the `TextAnnotator`.

The [suggested solution](https://arc.net/l/quote/mxgynitd) was to provide a custom `z-index` for the `bg` canvas to render it on top of any elements. It would be great to be able to provide such a style in a localized manner, only for the descendants of the auto-created `div` container:
```tsx
        ...
	return (
		<Annotorious>
			<TextAnnotatorComponent
				className={annotatorStyles}
				adapter={w3cAdapter}
				style={annotationStyle}>
				{children}
				<AnnotationPopup />
				<AnnotationsStorage {...props} />
				<TextAnnotatorPlugin plugin={webtextsPlugin} />
			</TextAnnotatorComponent>
		</Annotorious>
	);
};

const annotatorStyles = css`
	.r6o-highlight-layer.bg {
		z-index: 1;
	}
`;
```