### PR TITLE
Exported `NOT_ANNOTATABLE_CLASS`

### DIFF
--- a/packages/text-annotator/src/utils/splitAnnotatableRanges.ts
+++ b/packages/text-annotator/src/utils/splitAnnotatableRanges.ts
@@ -1,4 +1,4 @@
-const NOT_ANNOTATABLE_CLASS = 'not-annotatable';
+export const NOT_ANNOTATABLE_CLASS = 'not-annotatable';
 
 export const NOT_ANNOTATABLE_SELECTOR = `.${NOT_ANNOTATABLE_CLASS}`;
 


### PR DESCRIPTION
## Issue
Currently, the consuming apps, to declare that the element is not annotatable, use a "magic string" `not-annotatable`. Instead, they can import that value from the library. That ensures that there will be no typos or duplicated not annotatable identifiers declarations