### PR TITLE
Replaced usage of the `DrawingStyle` with the `HighlightStyleExpression`

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -1,10 +1,11 @@
 import { ReactNode, useContext, useEffect, useRef } from 'react';
-import { AnnotoriousContext, DrawingStyle, Filter } from '@annotorious/react';
+import { AnnotoriousContext, Filter } from '@annotorious/react';
 import type { FormatAdapter } from '@annotorious/core';
-import type { TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
+import type { HighlightStyleExpression, TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
 import { createTextAnnotator } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';
+
 
 export interface TextAnnotatorProps<E extends unknown> extends Omit<TextAnnotatorOptions<E>, 'adapter'>  {
 
@@ -14,7 +15,7 @@ export interface TextAnnotatorProps<E extends unknown> extends Omit<TextAnnotato
 
   filter?: Filter;
 
-  style?: DrawingStyle | ((annotation: TextAnnotation) => DrawingStyle);
+  style?: HighlightStyleExpression
 
   className?: string;
 

--- a/packages/text-annotator-react/src/tei/TEIAnnotator.tsx
+++ b/packages/text-annotator-react/src/tei/TEIAnnotator.tsx
@@ -1,8 +1,8 @@
 import { Children, ReactElement, ReactNode, cloneElement, useContext, useEffect } from 'react';
-import { AnnotoriousContext, DrawingStyle, Filter } from '@annotorious/react';
+import { AnnotoriousContext, Filter } from '@annotorious/react';
 import { TEIPlugin } from '@recogito/text-annotator-tei';
-import { createTextAnnotator } from '@recogito/text-annotator';
-import type { TextAnnotatorOptions, TextAnnotation } from '@recogito/text-annotator';
+import { createTextAnnotator, HighlightStyleExpression } from '@recogito/text-annotator';
+import type { TextAnnotatorOptions } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';
 
@@ -12,7 +12,7 @@ export type TEIAnnotatorProps = TextAnnotatorOptions & {
 
   filter?: Filter;
 
-  style?: DrawingStyle | ((annotation: TextAnnotation) => DrawingStyle);
+  style?: HighlightStyleExpression
 
 }
 

--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -82,8 +82,8 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
   const setFilter = (filter?: Filter) =>
     highlightRenderer.setFilter(filter);
 
-  const setStyle = (drawingStyle: HighlightStyleExpression | undefined) =>
-    highlightRenderer.setStyle(drawingStyle);
+  const setStyle = (style: HighlightStyleExpression | undefined) =>
+    highlightRenderer.setStyle(style);
 
   const setUser = (user: User) => {
     currentUser = user;

--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -1,6 +1,6 @@
-import { createAnonymousGuest, createLifecyleObserver, createBaseAnnotator, DrawingStyle, Filter, createUndoStack } from '@annotorious/core';
+import { createAnonymousGuest, createLifecyleObserver, createBaseAnnotator, Filter, createUndoStack } from '@annotorious/core';
 import type { Annotator, User, PresenceProvider } from '@annotorious/core';
-import { createCanvasRenderer, createHighlightsRenderer, createSpansRenderer } from './highlight';
+import { createCanvasRenderer, createHighlightsRenderer, createSpansRenderer, type HighlightStyleExpression } from './highlight';
 import { createPresencePainter } from './presence';
 import { scrollIntoView } from './api';
 import { TextAnnotationStore, TextAnnotatorState, createTextAnnotatorState } from './state';
@@ -9,6 +9,7 @@ import type { RendererType, TextAnnotatorOptions } from './TextAnnotatorOptions'
 import { SelectionHandler } from './SelectionHandler';
 
 import './TextAnnotator.css';
+
 
 const USE_DEFAULT_RENDERER: RendererType = 'SPANS';
 
@@ -81,7 +82,7 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
   const setFilter = (filter?: Filter) =>
     highlightRenderer.setFilter(filter);
 
-  const setStyle = (drawingStyle: DrawingStyle | ((annotation: TextAnnotation) => DrawingStyle) | undefined) =>
+  const setStyle = (drawingStyle: HighlightStyleExpression | undefined) =>
     highlightRenderer.setStyle(drawingStyle);
 
   const setUser = (user: User) => {

--- a/packages/text-annotator/src/TextAnnotatorOptions.ts
+++ b/packages/text-annotator/src/TextAnnotatorOptions.ts
@@ -1,7 +1,7 @@
-import type { DrawingStyle, FormatAdapter, PointerSelectAction } from '@annotorious/core';
+import type { FormatAdapter, PointerSelectAction } from '@annotorious/core';
 import type { PresencePainterOptions } from './presence';
 import type { TextAnnotation } from './model';
-import type { HighlightStyleExpression } from './highlight/HighlightStyle';
+import type { HighlightStyleExpression } from './highlight';
 
 export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
 

--- a/packages/text-annotator/src/highlight/index.ts
+++ b/packages/text-annotator/src/highlight/index.ts
@@ -1,3 +1,6 @@
+export * from './Highlight';
+export * from './HighlightStyle';
+export * from './HighlightPainter';
 export * from './canvas';
 export * from './highlights';
 export * from './span';


### PR DESCRIPTION
## Issue
In the https://github.com/recogito/text-annotator-js/commit/6b492616d062603bb509350fe1082068b89934e3 the `DrawingStyle | ((annotation: TextAnnotation) => DrawingStyle)` was replaced in majority of places with the text-specific alternative - `HighlightStyleExpression`.

But there were a few places where the `DrawingStyle` still was used. And, the `HighlightStyleExpression` wasn't exported from the `text-annotator` package.

## Changes Made
1. Removed the rest of the `DrawingStyle` usages and replaced it with the `HighlightStyleExpression`
2. Exported highlighting types that should be convenient to import from the package root