### PR TITLE
#80 Fixed annotating of the nested `not annotatable` content 

### DIFF
--- a/packages/text-annotator/src/utils/splitAnnotatableRanges.ts
+++ b/packages/text-annotator/src/utils/splitAnnotatableRanges.ts
@@ -14,7 +14,10 @@ const iterateNotAnnotatableElements = function*(range: Range): Generator<HTMLEle
     range.commonAncestorContainer,
     NodeFilter.SHOW_ELEMENT,
     (node) =>
-      node instanceof HTMLElement && node.classList.contains(NOT_ANNOTATABLE_CLASS) && range.intersectsNode(node)
+      node instanceof HTMLElement // Only elements that can have the class applied
+      && node.classList.contains(NOT_ANNOTATABLE_CLASS) // Only elements that are not annotatable
+      && !node.parentElement.closest(NOT_ANNOTATABLE_SELECTOR) // Only elements that are not descendants of a not annotatable element
+      && range.intersectsNode(node) // Only elements that are within the range
         ? NodeFilter.FILTER_ACCEPT
         : NodeFilter.FILTER_SKIP
   );

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -24,7 +24,8 @@
       }
 
       #content .not-annotatable {
-        background-color: wheat;
+        color: dimgray;
+        border: 3px solid wheat;
       }
 
       h1 {
@@ -107,13 +108,16 @@
         other gods:
       </p>
 
-      <p>
-        "See now, how men lay blame upon us gods for what is after all nothing but their own folly. Look at Aegisthus;
-        he must needs make love to Agamemnon's wife unrighteously and then kill Agamemnon, though he knew it would be
-        the death of him; for I sent Mercury to warn him not to do either of these things, inasmuch as Orestes would be
-        sure to take his revenge when he grew up and wanted to return home. Mercury told him this in all good will but
-        he would not listen, and now he has paid for everything in full."
-      </p>
+<div class="not-annotatable">
+  <h3>Not annotatable block!</h3>
+  <p>
+    "See now, how men lay blame upon us gods for what is after all nothing but their own folly. Look at Aegisthus;
+    he must needs make love to Agamemnon's wife unrighteously and then kill Agamemnon, though he knew it would be
+    the <span class="not-annotatable">death of him; for I sent Mercury to warn him not</span> to do either of these things, inasmuch as Orestes would be
+    sure to take his revenge when he grew up and wanted to return home. Mercury told him this in all good will but
+    he would not listen, and now he has paid for everything in full."
+  </p>
+</div>
 
       <p>
         Then Minerva said, "Father, son of Saturn, King of kings, it served Aegisthus right, and so it would any one


### PR DESCRIPTION
## Issue
This PR resolves the #80 issue, where the split of the selection range could happen on the nested `not-annotatable` element, leading to unexpected annotation range: 
![image](https://github.com/recogito/text-annotator-js/assets/68850090/f362995a-ea4b-4cf3-b9fd-93435102a5ef)

## Changes Made
- Excluded the nested not annotatable elements from the "split on them" gathering function
- Improved the styles for the not annotatable elements in the example

## Demo
![image](https://github.com/recogito/text-annotator-js/assets/68850090/1641a88c-65ae-4a7e-a609-955a86476495)
