### PR TITLE
Added text-specific `setStyle` override

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -17,6 +17,8 @@ export interface TextAnnotator<E extends unknown = TextAnnotation> extends Annot
 
   element: HTMLElement;
 
+  setStyle(style: HighlightStyleExpression | undefined): void;
+
   // Returns true if successful (or false if the annotation is not currently rendered)
   scrollIntoView(annotation: TextAnnotation): boolean;
 


### PR DESCRIPTION
## Issue
The `setStyle` method in the `TextAnnotator` was inherited from the `Annotator` type: 
```ts
setStyle(style: DrawingStyleExpression<I> | undefined): void;
```
But the actual type of this method for the text annotator is overridden and looks like:
```ts
setStyle(style: HighlightStyleExpression | undefined): void;
```
due to the following implementation:
https://github.com/recogito/text-annotator-js/blob/263a67ea2096dcc0d16be187393c6b94cecfe9bf/packages/text-annotator/src/TextAnnotator.ts#L85-L86

## Changes Made
Replaced the inherited type def for the `setStyle` with text-specific one