### PR TITLE
Removed redundant lifecycle generic argument

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -41,9 +41,7 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
 
   const undoStack = createUndoStack(store);
 
-  const lifecycle = createLifecyleObserver<TextAnnotation, TextAnnotation | E>(
-    state, undoStack, opts.adapter
-  );
+  const lifecycle = createLifecyleObserver<TextAnnotation, E>(state, undoStack, opts.adapter);
   
   let currentUser: User = createAnonymousGuest();
 


### PR DESCRIPTION
## Issue
The `TextAnnotation | E` technically is equal to the `E` and it doesn't change the TS behavior