### PR TITLE
Removed ambiguous `TextAnnotatorPlugin` export

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotatorPlugin.ts
+++ b/packages/text-annotator-react/src/TextAnnotatorPlugin.ts
@@ -1,5 +1,4 @@
-import { AnnotatorPlugin, AnnotoriousPlugin } from '@annotorious/react';
+import { AnnotatorPlugin } from '@annotorious/react';
 import type { TextAnnotator } from '@recogito/text-annotator';
 
 export type TextAnnotatorPlugin<T extends unknown = TextAnnotator> = AnnotatorPlugin<T>;
-export { AnnotoriousPlugin as TextAnnotatorPlugin }


### PR DESCRIPTION
## Issue
I accidentally added an ambiguous/duplicated definition for the `TextAnnotatorPlugin` within the `@recogito/react-text-annotator` package. Now I would say that users should use [the explicitly re-exported](https://github.com/recogito/text-annotator-js/commit/fca4a185fdec4f1b8f7c6709789fef0f1c4ad6f3) `AnnotoriousPlugin` component

