### PR TITLE
Added `underlineThickness` and `underlineOffset` handling for the `CANVAS` renderer

### DIFF
--- a/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
+++ b/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
@@ -53,47 +53,55 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
       painter.clear();
 
     const { top, left } = viewportBounds;
-    
+
     highlights.forEach(h => {
-      const base: HighlightStyle = currentStyle 
-        ? typeof currentStyle === 'function' 
-          ? currentStyle(h.annotation, h.state) 
-          : currentStyle 
-        : h.state?.selected 
-          ? DEFAULT_SELECTED_STYLE 
+      const base: HighlightStyle = currentStyle
+        ? typeof currentStyle === 'function'
+          ? currentStyle(h.annotation, h.state)
+          : currentStyle
+        : h.state?.selected
+          ? DEFAULT_SELECTED_STYLE
           : DEFAULT_STYLE;
 
       // Trigger the custom painter (if any) as a side-effect
       const style = painter ? painter.paint(h, viewportBounds) || base : base;
 
       // Offset annotation rects by current scroll position
-      const offsetRects = h.rects.map(({ x, y, width, height }) => ({ 
-        x: x + left, 
-        y: y + top, 
-        width, 
-        height 
+      const offsetRects = h.rects.map(({ x, y, width, height }) => ({
+        x: x + left,
+        y: y + top,
+        width,
+        height
       }));
 
       ctx.fillStyle = style.fill;
       ctx.globalAlpha = style.fillOpacity || 1;
-      
+
       offsetRects.forEach(({ x, y, width, height }) => ctx.fillRect(x, y - 2.5, width, height + 5));
 
       if (style.underlineColor) {
         ctx.globalAlpha = 1;
         ctx.strokeStyle = style.underlineColor;
+        ctx.lineWidth = style.underlineThickness ?? 1;
+
+        /**
+         * The underline should be drawn below the text,
+         * so it should be shifted 4px down by default
+         */
+        const defaultUnderlineOffset = 4;
+        const underlineOffset = defaultUnderlineOffset + (style.underlineOffset ?? 0);
 
         offsetRects.forEach(({ x, y, width, height }) => {
           ctx.beginPath();
-          ctx.moveTo(x, y + height + 4);
-          ctx.lineTo(x + width, y + height + 4);
-          
+          ctx.moveTo(x, y + height + underlineOffset);
+          ctx.lineTo(x + width, y + height + underlineOffset);
+
           // Draw the Path
           ctx.stroke();
         });
       }
     });
-  });  
+  });
 
   const onResize = debounce(() => {
     resetCanvas(canvas);

--- a/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
+++ b/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
@@ -77,19 +77,28 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
       ctx.fillStyle = style.fill;
       ctx.globalAlpha = style.fillOpacity || 1;
 
-      offsetRects.forEach(({ x, y, width, height }) => ctx.fillRect(x, y - 2.5, width, height + 5));
+
+      /**
+       * The default browser's selection highlight is a bit taller than the text itself.
+       * To match it, we need to draw the highlight a bit taller as well.
+       */
+      const selectionHighlightCompensation = 5;
+      offsetRects.forEach(({ x, y, width, height }) =>
+        ctx.fillRect(
+          x,
+          y - selectionHighlightCompensation / 2,
+          width,
+          height + selectionHighlightCompensation
+        )
+      );
 
       if (style.underlineColor) {
         ctx.globalAlpha = 1;
         ctx.strokeStyle = style.underlineColor;
         ctx.lineWidth = style.underlineThickness ?? 1;
 
-        /**
-         * The underline should be drawn below the text,
-         * so it should be shifted 4px down by default
-         */
-        const defaultUnderlineOffset = 4;
-        const underlineOffset = defaultUnderlineOffset + (style.underlineOffset ?? 0);
+        // Place the underline below the highlighted text + an optional offset
+        const underlineOffset = selectionHighlightCompensation / 2 + (style.underlineOffset ?? 0);
 
         offsetRects.forEach(({ x, y, width, height }) => {
           ctx.beginPath();

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -108,16 +108,16 @@
         other gods:
       </p>
 
-<div class="not-annotatable">
-  <h3>Not annotatable block!</h3>
-  <p>
-    "See now, how men lay blame upon us gods for what is after all nothing but their own folly. Look at Aegisthus;
-    he must needs make love to Agamemnon's wife unrighteously and then kill Agamemnon, though he knew it would be
-    the <span class="not-annotatable">death of him; for I sent Mercury to warn him not</span> to do either of these things, inasmuch as Orestes would be
-    sure to take his revenge when he grew up and wanted to return home. Mercury told him this in all good will but
-    he would not listen, and now he has paid for everything in full."
-  </p>
-</div>
+      <div class="not-annotatable">
+        <h3>Not annotatable block!</h3>
+        <p>
+          "See now, how men lay blame upon us gods for what is after all nothing but their own folly. Look at Aegisthus;
+          he must needs make love to Agamemnon's wife unrighteously and then kill Agamemnon, though he knew it would be
+          the <span class="not-annotatable">death of him; for I sent Mercury to warn him not</span> to do either of these things, inasmuch as Orestes would be
+          sure to take his revenge when he grew up and wanted to return home. Mercury told him this in all good will but
+          he would not listen, and now he has paid for everything in full."
+        </p>
+      </div>
 
       <p>
         Then Minerva said, "Father, son of Saturn, King of kings, it served Aegisthus right, and so it would any one
@@ -287,12 +287,13 @@
       window.onload = async () => {
         var contentContainer = document.getElementById('content');
 
-        const style = ((annotation, state, z) => ({
-          fillOpacity: 0.2,
-          underlineColor: '#00ff00',
-          underlineOffset: z * 3.5,
-          underlineThickness: 2
-        }));
+        const style = ((annotation, state, z) =>
+	        ({
+		        fillOpacity: 0.2,
+		        underlineColor: '#9b3c06',
+		        underlineOffset: (z * 3.5) || 0,
+		        underlineThickness: 2
+	        }));
 
         var r = createTextAnnotator(contentContainer, {
           adapter: W3CTextFormat('https://www.gutenberg.org', contentContainer),
@@ -367,7 +368,7 @@
         };
 
         var presenceButton = document.getElementById('fake-presence');
-        
+
         presenceButton.addEventListener('click', function () {
           if (remoteSelection) {
             remoteSelection = undefined;
@@ -386,7 +387,7 @@
         });
 
         // Make global so we can manipulate from the console
-        window.r = r; 
+        window.r = r;
       }
     </script>
   </body>


### PR DESCRIPTION
## Issue
Previously, only the `underlineColor` could be processed by the `CANVAS` renderer. But not the `underlineThickness` and `underlineOffset`.
