### PR TITLE
Expanded `@recogito/react-text-annotator` re-exports

### DIFF
--- a/packages/text-annotator-react/src/index.ts
+++ b/packages/text-annotator-react/src/index.ts
@@ -43,6 +43,12 @@ export {
 export type { 
   TextAnnotation,
   TextAnnotationTarget,
+  TextSelector,
+  W3CTextAnnotation,
+  W3CTextAnnotationTarget,
+  W3CTextSelector,
+  W3CAnnotationStylesheet,
+  HighlightStyle,
   TextAnnotator as RecogitoTextAnnotator,
-  TextSelector
+  TextAnnotationStore
 } from '@recogito/text-annotator';

--- a/packages/text-annotator-react/src/index.ts
+++ b/packages/text-annotator-react/src/index.ts
@@ -36,8 +36,8 @@ export const createBody = _createBody;
 export const Origin = _Origin;
 
 // Essential re-exports from @annotorious/react
-export type {
-  AnnotoriousPlugin
+export {
+ AnnotoriousPlugin
 } from '@annotorious/react';
 
 export type { 

--- a/packages/text-annotator-react/src/index.ts
+++ b/packages/text-annotator-react/src/index.ts
@@ -1,6 +1,7 @@
 export * from './tei';
 export * from './TextAnnotator';
 export * from './TextAnnotatorPopup';
+export * from './TextAnnotatorPlugin';
 
 // Essential re-exports from @annotorious/core
 export type {

--- a/packages/text-annotator-react/src/index.ts
+++ b/packages/text-annotator-react/src/index.ts
@@ -25,15 +25,11 @@ export type {
   W3CAnnotationTarget
 } from '@annotorious/core';
 
-import { 
-  createBody as _createBody,
-  Origin as _Origin,
-  PointerSelectAction as _PointerSelectAction
-} from '@annotorious/core'; 
-
-export const PointerSelectAction = _PointerSelectAction;
-export const createBody = _createBody;
-export const Origin = _Origin;
+export {
+  createBody,
+  Origin,
+  PointerSelectAction
+} from '@annotorious/core';
 
 // Essential re-exports from @annotorious/react
 export {

--- a/packages/text-annotator/src/index.ts
+++ b/packages/text-annotator/src/index.ts
@@ -29,12 +29,8 @@ export type {
   W3CAnnotationTarget
 } from '@annotorious/core';
 
-import { 
-  createBody as _createBody,
-  Origin as _Origin,
-  PointerSelectAction as _PointerSelectAction
-} from '@annotorious/core'; 
-
-export const PointerSelectAction = _PointerSelectAction;
-export const createBody = _createBody;
-export const Origin = _Origin;
+export {
+  createBody,
+  Origin,
+  PointerSelectAction
+} from '@annotorious/core';


### PR DESCRIPTION
## Issues
1. The `AnnotoriousPlugin` _component_ was re-exported as the _type_
2. The `TextAnnotation` types from the `@recogito/text-annotator` were not re-exported