### PR TITLE
#94 Added highlights sorting for the `CANVAS` renderer

### DIFF
--- a/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
+++ b/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
@@ -54,7 +54,20 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
 
     const { top, left } = viewportBounds;
 
-    highlights.forEach(h => {
+    /**
+     * Highlights rendering on the canvas is an order-sensitive operation.
+     * The later the highlight is rendered, the higher it will be in the visual stack.
+     *
+     * By default, we should expect that the newer highlight
+     * will be rendered over the older one
+     */
+    const creationSortedHighlights = [...highlights].sort((highlightA, highlightB) => {
+      const { annotation: { target: { created: createdA } } } = highlightA;
+      const { annotation: { target: { created: createdB } } } = highlightB;
+      return createdA.getTime() - createdB.getTime();
+    })
+
+    creationSortedHighlights.forEach(h => {
       const base: HighlightStyle = currentStyle
         ? typeof currentStyle === 'function'
           ? currentStyle(h.annotation, h.state)

--- a/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
+++ b/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
@@ -61,13 +61,13 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
      * By default, we should expect that the newer highlight
      * will be rendered over the older one
      */
-    const creationSortedHighlights = [...highlights].sort((highlightA, highlightB) => {
+    const highlightsByCreation = [...highlights].sort((highlightA, highlightB) => {
       const { annotation: { target: { created: createdA } } } = highlightA;
       const { annotation: { target: { created: createdB } } } = highlightB;
       return createdA.getTime() - createdB.getTime();
     })
 
-    creationSortedHighlights.forEach(h => {
+    highlightsByCreation.forEach(h => {
       const base: HighlightStyle = currentStyle
         ? typeof currentStyle === 'function'
           ? currentStyle(h.annotation, h.state)


### PR DESCRIPTION
## Issue https://github.com/recogito/text-annotator-js/issues/94

## Changes Made
Added simple sorting based on the annotation creation time before it will get drawn on the canvas