### PR TITLE
Dev container for node version switching and uniformity

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// Here we use node 20 with the bullseye release of Debian.
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash -i .devcontainer/postCreateCommand.sh",
+
+	// "postStartCommand": "bash  -i .devcontainer/postStartCommand.sh",
+
+	// Configure tool-specific properties.
+	// This adds a more advanced git 
+	"customizations": {
+		"vscode": {
+			"extensions": [
+			  "mhutchie.git-graph"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
+# xdg-open is used to open the browser in the vite start script
+# This is not installed by default in the node image
 sudo apt-get update 
 sudo apt-get install -y xdg-utils
 
-cd packages/extension-tei
-npm install
-
-cd packages/text-annotator
-npm install
-
-cd packages/text-annotator-react
 npm install

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+sudo apt-get update 
+sudo apt-get install -y xdg-utils
+
+cd packages/extension-tei
+npm install
+
+cd packages/text-annotator
+npm install
+
+cd packages/text-annotator-react
+npm install

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# This script is executed each time if the container is started.
+
+#cd /workspaces/text-annotator-js/packages/extension-tei
+#cd /workspaces/text-annotator-js/packages/text-annotator-react
+
+#cd packages/text-annotator
+
+#npm run start
+#npm run test


### PR DESCRIPTION
Hi,

In this pull request you can find a `.devcontainer` folder and minimal configuration to make `text-annotator-js` run.

Dev containers allow developers to quickly setup a sane dev environment with the expected node versions and associated dependencies a dev container helps. See the documentation here https://containers.dev/  

With VS code or other IDEs which support this construct it is practical to do development in such container. It makes it also easy to switch node versions to test older node versions.  A uniform dev environment should also make bugs more easy to replicate or report.

Added to the pull request are two scripts, one is executed once when the container is build, the other each time the container is started. 

It does add a dependency on docker and an additional folder. Thanks for considering this.

Joren

