### PR TITLE
Fixed reading of the `anchorNode: null` 

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -52,7 +52,7 @@ export const SelectionHandler = (
     // This is to handle cases where the selection is "hijacked" by another element
     // in a not-annotatable area. A rare case in theory. But rich text editors
     // will like Quill do it...
-    const annotatable = !sel.anchorNode.parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
+    const annotatable = !sel.anchorNode?.parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
     if (!annotatable) {
       currentTarget = undefined;
       return;


### PR DESCRIPTION
## Issue
One of the devs in my team reported that when using the latest version of the `@recogito/text-annotator`, the app started crashing with the following error:
![image](https://github.com/recogito/text-annotator-js/assets/68850090/7fd8fccd-3499-4b68-bd76-59476823e7b2)
He reported that the app  emits a synthetic `selectionchange` event right upon loading with the following shape: 
<img width="1086" alt="image" src="https://github.com/recogito/text-annotator-js/assets/68850090/95f0d241-b270-4af3-96c4-8a78dca5dd90">
Unfortunately, the `SelectionHandler` `selectionchange` event handler treats the `sel.anchorNode` as it's always present.

## Changes Made
Added `null` value handling for the `sel.anchorNode`