### PR TITLE
Added missing `openseadragon` transitive peer dependency

### DIFF
--- a/packages/text-annotator-react/package.json
+++ b/packages/text-annotator-react/package.json
@@ -35,8 +35,14 @@
     "vite-tsconfig-paths": "^4.3.2"
   },
   "peerDependencies": {
+    "openseadragon": "^3.0.0 || ^4.0.0",
     "react": "16.8.0 || >=17.x || >=18.x",
     "react-dom": "16.8.0 || >=17.x || >=18.x"
+  },
+  "peerDependenciesMeta": {
+    "openseadragon": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@annotorious/core": "^3.0.0-rc.25",


### PR DESCRIPTION
## Issue
The `@recogito/react-text-annotator` package depends on the `@annotorious/react` that has the `openseadragon` [defined as a peer](https://github.com/annotorious/annotorious/blob/0b8de66a9723cfa96335e552796dbedee85e7870/packages/annotorious-react/package.json#L35-L44). The `react-text-annotator` doesn't satisfy that dependency, therefore, it should propagate it further as a peer.