### PR TITLE
Added `updated` change upon `currentTarget` update

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -76,7 +76,8 @@ export const SelectionHandler = (
 
     currentTarget = {
       ...currentTarget,
-      selector: annotatableRanges.map(r => rangeToSelector(r, container, offsetReferenceSelector))
+      selector: annotatableRanges.map(r => rangeToSelector(r, container, offsetReferenceSelector)),
+      updated: new Date()
     };
 
     if (store.getAnnotation(currentTarget.annotation)) {


### PR DESCRIPTION
## Issue
Previously, the `updated` prop for the `annotation.target` was always `undefined` within the `TextAnnotator`. Although the target changes during the selection.

## Changes Made
Following the [`onChangeSelected` from `SVGDrawingLayer`](https://github.com/annotorious/annotorious/blob/0b8de66a9723cfa96335e552796dbedee85e7870/packages/annotorious-openseadragon/src/annotation/svg/drawing/SVGDrawingLayer.svelte#L137), I added `new Date()` for the `updated` prop on the selection change