### PR TITLE
#105 Fixed excessive cleanup of the newly added annotations

### DIFF
--- a/packages/text-annotator/src/state/TextAnnotatorState.ts
+++ b/packages/text-annotator/src/state/TextAnnotatorState.ts
@@ -130,15 +130,15 @@ export const createTextAnnotatorState = (
   const recalculatePositions = () => tree.recalculate();
 
   store.observe(({ changes }) => {
-    const created = (changes.created || []).filter(a => isRevived(a.target.selector));
     const deleted = (changes.deleted || []).filter(a => isRevived(a.target.selector));
+    const created = (changes.created || []).filter(a => isRevived(a.target.selector));
     const updated = (changes.updated || []).filter(u => isRevived(u.newValue.target.selector));
-
-    if (created.length > 0)
-      tree.set(created.map(a => a.target), false);
 
     if (deleted?.length > 0)
       deleted.forEach(a => tree.remove(a.target));
+
+    if (created.length > 0)
+      tree.set(created.map(a => a.target), false);
 
     if (updated?.length > 0)
       updated.forEach(({ newValue }) => tree.update(newValue.target));

--- a/packages/text-annotator/src/state/spatialTree.ts
+++ b/packages/text-annotator/src/state/spatialTree.ts
@@ -103,7 +103,7 @@ export const createSpatialTree = (store: Store<TextAnnotation>, container: HTMLE
     const rectsByTarget = targets.map(target => ({ target, rects: toItems(target, offset) }));
     rectsByTarget.forEach(({ target, rects }) => index.set(target.annotation, rects));
 
-    const allRects = rectsByTarget.reduce((all, { rects }) => [...all, ...rects], []);
+    const allRects = rectsByTarget.flatMap(({ rects }) => rects);
     tree.load(allRects);
   }
 

--- a/packages/text-annotator/src/state/spatialTree.ts
+++ b/packages/text-annotator/src/state/spatialTree.ts
@@ -170,7 +170,7 @@ export const createSpatialTree = (store: Store<TextAnnotation>, container: HTMLE
     const rects = tree.search({ minX, minY, maxX, maxY });
 
     // Distinct annotation IDs
-    const annotationIds = new Set(rects.reduce<string[]>((ids, rect) => ([...ids, rect.annotation.id]), []));
+    const annotationIds = new Set(rects.map(rect => rect.annotation.id));
 
     // Resolve annotation IDs. Note that the tree could be slightly out of sync (because 
     // it updates by listening to changes, just like anyone else)


### PR DESCRIPTION
## Issue
See - https://github.com/recogito/text-annotator-js/issues/105#issuecomment-2165512886

> When the newly set annotation has the same id as the removed one - the [store observer](https://github.com/recogito/text-annotator-js/blob/6a2097075860d49dee2df27286bc9e23d5531707/packages/text-annotator/src/state/TextAnnotatorState.ts#L132-L145) in the `TextAnnotatorState` accidentally cleans it out:
![image](https://github.com/recogito/text-annotator-js/assets/68850090/10ce728f-6b14-4ef4-a922-bed63f1bbedc)

## Changes Made
Made deletion processing happen before the creation & update. Therefore, if the new annotation has the same id as the deleted one - it'll still get persisted in the spatial tree