### PR TITLE
Bumped `@annotorious` dependencies to `^3.0.0-rc.29`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,19 +28,21 @@
       }
     },
     "node_modules/@annotorious/annotorious": {
-      "version": "3.0.0-rc.28",
-      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.0.0-rc.28.tgz",
-      "integrity": "sha512-UJHa19zc+KmdsAen+k3rsB50yqZQsekgo8uewdEFH0TBNd6IGBDDdxofm5U1SimHM+O7SKdJkKqNUnwBez9Kqg==",
+      "version": "3.0.0-rc.29",
+      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.0.0-rc.29.tgz",
+      "integrity": "sha512-Snt/htM3fdjTipsIRBS+y29n8Npbmpaw4egMFdQxs+1/tlVFIXzgH3KxUNWYTgnlIQMLzXlTauHjjtYySBcOYA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/core": "3.0.0-rc.28",
+        "@annotorious/core": "3.0.0-rc.29",
         "rbush": "^3.0.1",
         "uuid": "^10.0.0"
       }
     },
     "node_modules/@annotorious/core": {
-      "version": "3.0.0-rc.28",
-      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.0.0-rc.28.tgz",
-      "integrity": "sha512-7FwSVhuDKEthKBtev2npDqBNB9OXQ3RtQzgr7+rba29Gc3CX/B3HXfDDi/y4u5RgZFpudeg6ifDPq4Zl+rmO1Q==",
+      "version": "3.0.0-rc.29",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.0.0-rc.29.tgz",
+      "integrity": "sha512-C2xjeOmNwGaqnQXW5pKlQLFo8RkoQZK27XJ2F09KqJhbFpMYtyDztCxPM/7mHOJeCPHsr25zW8taDpeeZdWtsQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "dequal": "^2.0.3",
         "nanoevents": "^9.0.0",
@@ -49,12 +51,13 @@
       }
     },
     "node_modules/@annotorious/openseadragon": {
-      "version": "3.0.0-rc.28",
-      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.0.0-rc.28.tgz",
-      "integrity": "sha512-Z6uMADSt/Gmy6I6ylu7Zt9e1i4MvnhJ3zFtFrMO26YL2P2GciDXEfyJnwv+xhqD110ZA43hmNZcqVmYGv0+lOg==",
+      "version": "3.0.0-rc.29",
+      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.0.0-rc.29.tgz",
+      "integrity": "sha512-jTkHPNac/olqH81OUq+XhDq++Ar0MXEeOyz8H3VMv0U6CiWLB6/yvF0u2cNY0KAywrr0oF1egB1pYwdjwRQtgg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "3.0.0-rc.28",
-        "@annotorious/core": "3.0.0-rc.28",
+        "@annotorious/annotorious": "3.0.0-rc.29",
+        "@annotorious/core": "3.0.0-rc.29",
         "pixi.js": "^7.4.2",
         "uuid": "^10.0.0"
       },
@@ -63,13 +66,14 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "version": "3.0.0-rc.28",
-      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-rc.28.tgz",
-      "integrity": "sha512-j2sq32DyXRiKS023B2hQqKIv2gLHUJ+eJ3n7xDnE3Bb2cOsyuJU4MglqpAYj/brH4EI0SxmLYa2dgQBY70kI+w==",
+      "version": "3.0.0-rc.29",
+      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-rc.29.tgz",
+      "integrity": "sha512-XFp5inVWERwoh+FJwkXoewSjJaWxRN2dsiALWspcMuEeD7PGftfKhAeeJiFMJkHgh2GYl5lss3lLA9W3Mc7Xmg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "3.0.0-rc.28",
-        "@annotorious/core": "3.0.0-rc.28",
-        "@annotorious/openseadragon": "3.0.0-rc.28",
+        "@annotorious/annotorious": "3.0.0-rc.29",
+        "@annotorious/core": "3.0.0-rc.29",
+        "@annotorious/openseadragon": "3.0.0-rc.29",
         "@neodrag/react": "^2.0.4"
       },
       "peerDependencies": {
@@ -1012,6 +1016,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.2.tgz",
       "integrity": "sha512-R6VEolm8uyy1FB1F2qaLKxVbzXAFTZCF2ka8fl9lsz7We6ZfO4QpXv9ur7DvzratjCQUQVCKo0/V7xL5q1EV/g==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2",
@@ -1022,6 +1027,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.2.tgz",
       "integrity": "sha512-ugkH3kOgjT8P1mTMY29yCOgEh+KuVMAn8uBxeY0aMqaUgIMysfpnFv+Aepp2CtvI9ygr22NC+OiKl+u+eEaQHw==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2"
@@ -1031,6 +1037,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.2.tgz",
       "integrity": "sha512-anxho59H9egZwoaEdM5aLvYyxoz6NCy3CaQIvNHD1bbGg8L16Ih0e26QSBR5fu53jl8OjT6M7s+p6n7uu4+fGA==",
+      "license": "MIT",
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.12"
       },
@@ -1042,6 +1049,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.2.tgz",
       "integrity": "sha512-av1LOvhHsiaW8+T4n/FgnOKHby55/w7VcA1HzPIHRBtEcsmxvSCDanT1HU2LslNhrxLPzyVx18nlmalOyt5OBg==",
+      "license": "MIT",
       "dependencies": {
         "@pixi/colord": "^2.9.6"
       }
@@ -1049,12 +1057,14 @@
     "node_modules/@pixi/colord": {
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
-      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
     },
     "node_modules/@pixi/compressed-textures": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.2.tgz",
       "integrity": "sha512-VJrt7el6O4ZJSWkeOGXwrhJaiLg1UBhHB3fj42VR4YloYkAxpfd9K6s6IcbcVz7n9L48APKBMgHyaB2pX2Ck/A==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/assets": "7.4.2",
         "@pixi/core": "7.4.2"
@@ -1063,12 +1073,14 @@
     "node_modules/@pixi/constants": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.2.tgz",
-      "integrity": "sha512-N9vn6Wpz5WIQg7ugUg2+SdqD2u2+NM0QthE8YzLJ4tLH2Iz+/TrnPKUJzeyIqbg3sxJG5ZpGGPiacqIBpy1KyA=="
+      "integrity": "sha512-N9vn6Wpz5WIQg7ugUg2+SdqD2u2+NM0QthE8YzLJ4tLH2Iz+/TrnPKUJzeyIqbg3sxJG5ZpGGPiacqIBpy1KyA==",
+      "license": "MIT"
     },
     "node_modules/@pixi/core": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.2.tgz",
       "integrity": "sha512-UbMtgSEnyCOFPzbE6ThB9qopXxbZ5GCof2ArB4FXOC5Xi/83MOIIYg5kf5M8689C5HJMhg2SrJu3xLKppF+CMg==",
+      "license": "MIT",
       "dependencies": {
         "@pixi/color": "7.4.2",
         "@pixi/constants": "7.4.2",
@@ -1088,6 +1100,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.2.tgz",
       "integrity": "sha512-DaD0J7gIlNlzO0Fdlby/0OH+tB5LtCY6rgFeCBKVDnzmn8wKW3zYZRenWBSFJ0Psx6vLqXYkSIM/rcokaKviIw==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2"
       }
@@ -1096,6 +1109,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.2.tgz",
       "integrity": "sha512-Jw/w57heZjzZShIXL0bxOvKB+XgGIevyezhGtfF2ZSzQoSBWo+Fj1uE0QwKd0RIaXegZw/DhSmiMJSbNmcjifA==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2"
@@ -1104,12 +1118,14 @@
     "node_modules/@pixi/extensions": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.2.tgz",
-      "integrity": "sha512-Hmx2+O0yZ8XIvgomHM9GZEGcy9S9Dd8flmtOK5Aa3fXs/8v7xD08+ANQpN9ZqWU2Xs+C6UBlpqlt2BWALvKKKA=="
+      "integrity": "sha512-Hmx2+O0yZ8XIvgomHM9GZEGcy9S9Dd8flmtOK5Aa3fXs/8v7xD08+ANQpN9ZqWU2Xs+C6UBlpqlt2BWALvKKKA==",
+      "license": "MIT"
     },
     "node_modules/@pixi/extract": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.2.tgz",
       "integrity": "sha512-JOX27TRWjVEjauGBbF8PU7/g6LYXnivehdgqS5QlVDv1CNHTOrz/j3MdKcVWOhyZPbH5c9sh7lxyRxvd9AIuTQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2"
       }
@@ -1118,6 +1134,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.2.tgz",
       "integrity": "sha512-9OsKJ+yvY2wIcQXwswj5HQBiwNGymwmqdxfp7mo+nZSBoDmxUqvMZzE9UNJ3eUlswuNvNRO8zNOsQvwdz7WFww==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2"
       }
@@ -1126,6 +1143,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.2.tgz",
       "integrity": "sha512-gOXBbIUx6CRZP1fmsis2wLzzSsofrqmIHhbf1gIkZMIQaLsc9T7brj+PaLTTiOiyJgnvGN5j20RZnkERWWKV0Q==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2"
       }
@@ -1134,6 +1152,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.2.tgz",
       "integrity": "sha512-ykZiR59Gvj80UKs9qm7jeUTKvn+wWk6HBVJOmJbK9jFK5juakDWp7BbH26U78Q61EWj97kI1FdfcbMkuQ7rqkA==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2"
       }
@@ -1142,6 +1161,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.2.tgz",
       "integrity": "sha512-QS/eWp/ivsxef3xapNeGwpPX7vrqQQeo99Fux4k5zsvplnNEsf91t6QYJLG776AbZEu/qh8VYRBA5raIVY/REw==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2"
       }
@@ -1150,6 +1170,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.2.tgz",
       "integrity": "sha512-U/ptJgDsfs/r8y2a6gCaiPfDu2IFAxpQ4wtfmBpz6vRhqeE4kI8yNIUx5dZbui57zlsJaW0BNacOQxHU0vLkyQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2"
       }
@@ -1158,6 +1179,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.2.tgz",
       "integrity": "sha512-Vy9ViBFhZEGh6xKkd3kFWErolZTwv1Y5Qb1bV7qPIYbvBECYsqzlR4uCrrjBV6KKm0PufpG/+NKC5vICZaqKzg==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2"
       }
@@ -1166,6 +1188,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.2.tgz",
       "integrity": "sha512-jH4/Tum2RqWzHGzvlwEr7HIVduoLO57Ze705N2zQPkUD57TInn5911aGUeoua7f/wK8cTLGzgB9BzSo2kTdcHw==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2",
@@ -1175,12 +1198,14 @@
     "node_modules/@pixi/math": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.2.tgz",
-      "integrity": "sha512-7jHmCQoYk6e0rfSKjdNFOPl0wCcdgoraxgteXJTTHv3r0bMNx2pHD9FJ0VvocEUG7XHfj55O3+u7yItOAx0JaQ=="
+      "integrity": "sha512-7jHmCQoYk6e0rfSKjdNFOPl0wCcdgoraxgteXJTTHv3r0bMNx2pHD9FJ0VvocEUG7XHfj55O3+u7yItOAx0JaQ==",
+      "license": "MIT"
     },
     "node_modules/@pixi/mesh": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.2.tgz",
       "integrity": "sha512-mEkKyQvvMrYXC3pahvH5WBIKtrtB63WixRr91ANFI7zXD+ESG6Ap6XtxMCJmXDQPwBDNk7SWVMiCflYuchG7kA==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2"
@@ -1190,6 +1215,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.2.tgz",
       "integrity": "sha512-vNR/7wjxjs7sv9fGoKkHyU91ZAD+7EnMHBS5F3CVISlOIFxLi96NNZCB81oUIdky/90pHw40johd/4izR5zTyw==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/mesh": "7.4.2"
@@ -1199,6 +1225,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.2.tgz",
       "integrity": "sha512-6dgthi2ruUT/lervSrFDQ7vXkEsHo6CxdgV7W/wNdW1dqgQlKfDvO6FhjXzyIMRLSooUf5FoeluVtfsjkUIYrw==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2",
@@ -1209,6 +1236,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.2.tgz",
       "integrity": "sha512-0Cfw8JpQhsixprxiYph4Lj+B5n83Kk4ftNMXgM5xtZz+tVLz5s91qR0MqcdzwTGTJ7utVygiGmS4/3EfR/duRQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/display": "7.4.2"
       }
@@ -1217,6 +1245,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.2.tgz",
       "integrity": "sha512-LcsahbVdX4DFS2IcGfNp4KaXuu7SjAwUp/flZSGIfstyKOKb5FWFgihtqcc9ZT4coyri3gs2JbILZub/zPZj1w==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2"
@@ -1226,6 +1255,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.2.tgz",
       "integrity": "sha512-B78Qq86kt0lEa5WtB2YFIm3+PjhKfw9La9R++GBSgABl+g13s2UaZ6BIPxvY3JxWMdxPm4iPrQPFX1QWRN68mw==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2",
@@ -1236,6 +1266,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.2.tgz",
       "integrity": "sha512-PugyMzReCHXUzc3so9PPJj2OdHwibpUNWyqG4mWY2UUkb6c8NAGK1AnAPiscOvLilJcv/XQSFoNhX+N1jrvJEg==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2",
@@ -1246,12 +1277,14 @@
     "node_modules/@pixi/runner": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.2.tgz",
-      "integrity": "sha512-LPBpwym4vdyyDY5ucF4INQccaGyxztERyLTY1YN6aqJyyMmnc7iqXlIKt+a0euMBtNoLoxy6MWMvIuZj0JfFPA=="
+      "integrity": "sha512-LPBpwym4vdyyDY5ucF4INQccaGyxztERyLTY1YN6aqJyyMmnc7iqXlIKt+a0euMBtNoLoxy6MWMvIuZj0JfFPA==",
+      "license": "MIT"
     },
     "node_modules/@pixi/settings": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.2.tgz",
       "integrity": "sha512-pMN+L6aWgvUbwhFIL/BTHKe2ShYGPZ8h9wlVBnFHMtUcJcFLMF1B3lzuvCayZRepOphs6RY0TqvnDvVb585JhQ==",
+      "license": "MIT",
       "dependencies": {
         "@pixi/constants": "7.4.2",
         "@types/css-font-loading-module": "^0.0.12",
@@ -1262,6 +1295,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.2.tgz",
       "integrity": "sha512-Ccf/OVQsB+HQV0Fyf5lwD+jk1jeU7uSIqEjbxenNNssmEdB7S5qlkTBV2EJTHT83+T6Z9OMOHsreJZerydpjeg==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2"
@@ -1271,6 +1305,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.2.tgz",
       "integrity": "sha512-QPT6yxCUGOBN+98H3pyIZ1ZO6Y7BN1o0Q2IMZEsD1rNfZJrTYS3Q8VlCG5t2YlFlcB8j5iBo24bZb6FUxLOmsQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/sprite": "7.4.2"
@@ -1280,6 +1315,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.2.tgz",
       "integrity": "sha512-Z8PP6ewy3nuDYL+NeEdltHAhuucVgia33uzAitvH3OqqRSx6a6YRBFbNLUM9Sx+fBO2Lk3PpV1g6QZX+NE5LOg==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2",
@@ -1290,6 +1326,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.2.tgz",
       "integrity": "sha512-YIvHdpXW+AYp8vD0NkjJmrdnVHTZKidCnx6k8ATSuuvCT6O5Tuh2N/Ul2oDj4/QaePy0lVhyhAbZpJW00Jr7mQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/assets": "7.4.2",
         "@pixi/core": "7.4.2"
@@ -1299,6 +1336,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.2.tgz",
       "integrity": "sha512-rZZWpJNsIQ8WoCWrcVg8Gi6L/PDakB941clo6dO3XjoII2ucoOUcnpe5HIkudxi2xPvS/8Bfq990gFEx50TP5A==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/sprite": "7.4.2"
@@ -1308,6 +1346,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.2.tgz",
       "integrity": "sha512-lPBMJ83JnpFVL+6ckQ8KO8QmwdPm0z9Zs/M0NgFKH2F+BcjelRNnk80NI3O0qBDYSEDQIE+cFbKoZ213kf7zwA==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/assets": "7.4.2",
         "@pixi/core": "7.4.2",
@@ -1320,6 +1359,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.2.tgz",
       "integrity": "sha512-duOu8oDYeDNuyPozj2DAsQ5VZBbRiwIXy78Gn7H2pCiEAefw/Uv5jJYwdgneKME0e1tOxz1eOUGKPcI6IJnZjw==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.2",
         "@pixi/display": "7.4.2",
@@ -1331,6 +1371,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.2.tgz",
       "integrity": "sha512-cAvxCh/KI6IW4m3tp2b+GQIf+DoSj9NNmPJmsOeEJ7LzvruG8Ps7SKI6CdjQob5WbceL1apBTDbqZ/f77hFDiQ==",
+      "license": "MIT",
       "dependencies": {
         "@pixi/extensions": "7.4.2",
         "@pixi/settings": "7.4.2",
@@ -1341,6 +1382,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.2.tgz",
       "integrity": "sha512-aU/itcyMC4TxFbmdngmak6ey4kC5c16Y5ntIYob9QnjNAfD/7GTsYIBnP6FqEAyO1eq0MjkAALxdONuay1BG3g==",
+      "license": "MIT",
       "dependencies": {
         "@pixi/color": "7.4.2",
         "@pixi/constants": "7.4.2",
@@ -1774,12 +1816,14 @@
     "node_modules/@types/css-font-loading-module": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
-      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA=="
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
+      "license": "MIT"
     },
     "node_modules/@types/earcut": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
-      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ=="
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -2214,6 +2258,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -2485,6 +2530,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -2526,7 +2572,8 @@
     "node_modules/earcut": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.799",
@@ -2550,6 +2597,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -2561,6 +2609,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -2633,7 +2682,8 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -2751,6 +2801,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -2796,6 +2847,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -2822,6 +2874,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -2833,6 +2886,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2844,6 +2898,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2987,7 +3042,8 @@
     "node_modules/ismobilejs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
     },
     "node_modules/jju": {
       "version": "1.4.0",
@@ -3312,6 +3368,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3435,6 +3492,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.2.tgz",
       "integrity": "sha512-TifqgHGNofO7UCEbdZJOpUu7dUnpu4YZ0o76kfCqxDa4RS8ITc9zjECCbtalmuNXkVhSEZmBKQvE7qhHMqw/xg==",
+      "license": "MIT",
       "dependencies": {
         "@pixi/accessibility": "7.4.2",
         "@pixi/app": "7.4.2",
@@ -3574,6 +3632,7 @@
       "version": "6.12.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
       "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -3744,6 +3803,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -3781,6 +3841,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -4125,6 +4186,7 @@
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
       "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "license": "MIT",
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.11.2"
@@ -4143,7 +4205,8 @@
     "node_modules/url/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "10.0.0",
@@ -4564,7 +4627,7 @@
         "vite-plugin-dts": "^3.9.1"
       },
       "peerDependencies": {
-        "@annotorious/core": "^3.0.0-rc.28",
+        "@annotorious/core": "^3.0.0-rc.29",
         "@recogito/text-annotator": "3.0.0-rc.30"
       }
     },
@@ -4573,7 +4636,7 @@
       "version": "3.0.0-rc.30",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/core": "^3.0.0-rc.28",
+        "@annotorious/core": "^3.0.0-rc.29",
         "colord": "^2.9.3",
         "dequal": "^2.0.3",
         "rbush": "^3.0.1",
@@ -4596,8 +4659,8 @@
       "version": "3.0.0-rc.30",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/core": "^3.0.0-rc.28",
-        "@annotorious/react": "^3.0.0-rc.28",
+        "@annotorious/core": "^3.0.0-rc.29",
+        "@annotorious/react": "^3.0.0-rc.29",
         "@floating-ui/react": "^0.26.16",
         "@recogito/text-annotator": "3.0.0-rc.30",
         "@recogito/text-annotator-tei": "3.0.0-rc.30",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4543,10 +4543,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/packages/extension-tei/package.json
+++ b/packages/extension-tei/package.json
@@ -32,7 +32,7 @@
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@annotorious/core": "^3.0.0-rc.28",
+    "@annotorious/core": "^3.0.0-rc.29",
     "@recogito/text-annotator": "3.0.0-rc.30"
   }
 }

--- a/packages/text-annotator-react/package.json
+++ b/packages/text-annotator-react/package.json
@@ -45,8 +45,8 @@
     }
   },
   "dependencies": {
-    "@annotorious/core": "^3.0.0-rc.28",
-    "@annotorious/react": "^3.0.0-rc.28",
+    "@annotorious/core": "^3.0.0-rc.29",
+    "@annotorious/react": "^3.0.0-rc.29",
     "@floating-ui/react": "^0.26.16",
     "@recogito/text-annotator": "3.0.0-rc.30",
     "@recogito/text-annotator-tei": "3.0.0-rc.30",

--- a/packages/text-annotator/package.json
+++ b/packages/text-annotator/package.json
@@ -37,7 +37,7 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
-    "@annotorious/core": "^3.0.0-rc.28",
+    "@annotorious/core": "^3.0.0-rc.29",
     "colord": "^2.9.3",
     "dequal": "^2.0.3",
     "rbush": "^3.0.1",


### PR DESCRIPTION
## Issue
In `@annotorious/core@3.0.0-rc.29` a [critical fix](https://github.com/annotorious/annotorious/pull/409) for the `Lifecycle` observers memory leakage was released. So it would make sense to migrate the `text-annotator-js` to the newer version as well