### PR TITLE
#109 Removed selection highlight height compensation in `CANVAS`

### DIFF
--- a/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
+++ b/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
@@ -14,7 +14,7 @@ const createCanvas = () => {
   canvas.height = window.innerHeight;
   canvas.className = 'r6o-highlight-layer bg';
   return canvas;
-}
+};
 
 const resetCanvas = (canvas: HTMLCanvasElement, highres?: boolean) => {
   canvas.width = highres ? 2 * window.innerWidth : window.innerWidth;
@@ -26,7 +26,7 @@ const resetCanvas = (canvas: HTMLCanvasElement, highres?: boolean) => {
     context.scale(2, 2);
     context.translate(0.5, 0.5);
   }
-}
+};
 
 const createRenderer = (container: HTMLElement): RendererImplementation => {
 
@@ -37,8 +37,8 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
 
   container.insertBefore(canvas, container.firstChild);
 
-  const redraw = (   
-    highlights: Highlight[], 
+  const redraw = (
+    highlights: Highlight[],
     viewportBounds: ViewportBounds,
     currentStyle?: HighlightStyleExpression,
     currentPainter?: HighlightPainter
@@ -65,7 +65,7 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
       const { annotation: { target: { created: createdA } } } = highlightA;
       const { annotation: { target: { created: createdB } } } = highlightB;
       return createdA.getTime() - createdB.getTime();
-    })
+    });
 
     highlightsByCreation.forEach(h => {
       const base: HighlightStyle = currentStyle
@@ -90,19 +90,8 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
       ctx.fillStyle = style.fill;
       ctx.globalAlpha = style.fillOpacity || 1;
 
-
-      /**
-       * The default browser's selection highlight is a bit taller than the text itself.
-       * To match it, we need to draw the highlight a bit taller as well.
-       */
-      const selectionHighlightCompensation = 5;
       offsetRects.forEach(({ x, y, width, height }) =>
-        ctx.fillRect(
-          x,
-          y - selectionHighlightCompensation / 2,
-          width,
-          height + selectionHighlightCompensation
-        )
+        ctx.fillRect(x, y, width, height)
       );
 
       if (style.underlineColor) {
@@ -111,7 +100,7 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
         ctx.lineWidth = style.underlineThickness ?? 1;
 
         // Place the underline below the highlighted text + an optional offset
-        const underlineOffset = selectionHighlightCompensation / 2 + (style.underlineOffset ?? 0);
+        const underlineOffset = style.underlineOffset ?? 0;
 
         offsetRects.forEach(({ x, y, width, height }) => {
           ctx.beginPath();
@@ -133,24 +122,24 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
 
   const setVisible = (visible: boolean) => {
     console.log('setVisible not implemented on Canvas renderer');
-  }
+  };
 
   const destroy = () => {
     container.removeChild(canvas);
 
     window.removeEventListener('resize', onResize);
-  }
+  };
 
   return {
     destroy,
     setVisible,
     redraw
-  }
+  };
 
-}
+};
 
 export const createCanvasRenderer = (
-  container: HTMLElement, 
+  container: HTMLElement,
   state: TextAnnotatorState,
   viewport: ViewportState
 ) => createBaseRenderer(container, state, viewport, createRenderer(container));

--- a/packages/text-annotator/src/highlight/highlights/highlightsRenderer.ts
+++ b/packages/text-annotator/src/highlight/highlights/highlightsRenderer.ts
@@ -21,7 +21,7 @@ const toCSS = (s?: HighlightStyle) => {
   ].filter(Boolean);
 
   return rules.join(';');
-}
+};
 
 export const createRenderer = (): RendererImplementation => {
   const elem = document.createElement('style');
@@ -30,7 +30,7 @@ export const createRenderer = (): RendererImplementation => {
   let currentRendered = new Set<string>();
 
   const redraw = (
-    highlights: Highlight[], 
+    highlights: Highlight[],
     viewportBounds: ViewportBounds,
     currentStyle?: HighlightStyleExpression,
     painter?: HighlightPainter
@@ -46,10 +46,10 @@ export const createRenderer = (): RendererImplementation => {
 
     // For simplicity, re-generate the whole stylesheet
     const updatedCSS = highlights.map(h => {
-      const base = currentStyle 
-        ? typeof currentStyle === 'function' 
-          ? currentStyle(h.annotation, h.state) 
-          : currentStyle 
+      const base = currentStyle
+        ? typeof currentStyle === 'function'
+          ? currentStyle(h.annotation, h.state)
+          : currentStyle
         : h.state?.selected ? DEFAULT_SELECTED_STYLE : DEFAULT_STYLE;
 
       // Trigger the custom painter (if any) as a side-effect
@@ -70,7 +70,7 @@ export const createRenderer = (): RendererImplementation => {
 
     // Could be improved further by (re-)setting only annotations that
     // have changes.
-    highlights.forEach(({ annotation }) => { 
+    highlights.forEach(({ annotation }) => {
       const ranges = annotation.target.selector.map(s => s.range);
 
       // @ts-ignore
@@ -81,11 +81,11 @@ export const createRenderer = (): RendererImplementation => {
     });
 
     currentRendered = nextRendered;
-  }
+  };
 
   const setVisible = (visible: boolean) => {
     console.log('setVisible not implemented on CSS Custom Highlights renderer');
-  }
+  };
 
   const destroy = () => {
     // Clear all highlights from the Highlight Registry
@@ -94,18 +94,18 @@ export const createRenderer = (): RendererImplementation => {
 
     // Remove the stylesheet
     elem.remove();
-  }
+  };
 
   return {
     destroy,
     setVisible,
     redraw
-  }
+  };
 
-}
+};
 
 export const createHighlightsRenderer = (
-  container: HTMLElement, 
+  container: HTMLElement,
   state: TextAnnotatorState,
   viewport: ViewportState
 ) => createBaseRenderer(container, state, viewport, createRenderer());

--- a/packages/text-annotator/src/highlight/span/spansRenderer.ts
+++ b/packages/text-annotator/src/highlight/span/spansRenderer.ts
@@ -2,7 +2,7 @@ import type { ViewportState } from '@annotorious/core';
 import { colord } from 'colord';
 import { dequal } from 'dequal/lite';
 import type { Rect, TextAnnotatorState } from '../../state';
-import { paint, type HighlightPainter } from '../HighlightPainter';
+import { type HighlightPainter, paint } from '../HighlightPainter';
 import type { ViewportBounds } from '../viewport';
 import { createBaseRenderer, type RendererImplementation } from '../baseRenderer';
 import type { Highlight } from '../Highlight';
@@ -21,7 +21,7 @@ const computeZIndex = (rect: Rect, all: Rect[]): number => {
     intersects(rect, other) &&
     other.width > rect.width
   )).length;
-}
+};
 
 const createRenderer = (container: HTMLElement): RendererImplementation => {
 
@@ -36,12 +36,12 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
   let currentRendered: Highlight[] = [];
 
   const redraw = (
-    highlights: Highlight[], 
+    highlights: Highlight[],
     viewportBounds: ViewportBounds,
     currentStyle?: HighlightStyleExpression,
     painter?: HighlightPainter,
     lazy?: boolean
-  ) => {    
+  ) => {
     const noChanges = dequal(currentRendered, highlights);
 
     // If there are no changes and rendering is set to lazy
@@ -71,11 +71,9 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
           span.style.width = `${rect.width}px`;
           span.style.height = `${rect.height}px`;
 
-          const backgroundColor = colord(style?.fill || DEFAULT_STYLE.fill)
+          span.style.backgroundColor = colord(style?.fill || DEFAULT_STYLE.fill)
             .alpha(style?.fillOpacity === undefined ? DEFAULT_STYLE.fillOpacity : style.fillOpacity)
             .toHex();
-
-          span.style.backgroundColor = backgroundColor;
 
           if (style.underlineStyle)
             span.style.borderStyle = style.underlineStyle;
@@ -95,29 +93,29 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
     });
 
     currentRendered = highlights;
-  }
+  };
 
   const setVisible = (visible: boolean) => {
     if (visible)
       highlightLayer.classList.remove('hidden');
     else
       highlightLayer.classList.add('hidden');
-  }
+  };
 
   const destroy = () => {
     highlightLayer.remove();
-  }
+  };
 
   return {
     destroy,
     redraw,
     setVisible
-  }
+  };
 
-}
+};
 
 export const createSpansRenderer = (
-  container: HTMLElement, 
+  container: HTMLElement,
   state: TextAnnotatorState,
   viewport: ViewportState
 ) => createBaseRenderer(container, state, viewport, createRenderer(container));


### PR DESCRIPTION
## Issue
See - https://github.com/recogito/text-annotator-js/issues/109#issuecomment-2198591493

## Changes Made
I removed the `selectionHighlightCompensation` variable from the `CANVAS` highlights renderer. It makes the highlight always follow the dimensions reported by the `range.getClientRects`. 

## Demo
| Chrome | Safari | Firefox |
|:----------:|:----------:|:----------:|
 | The default highlight is taller than the rendered one, both at the top & bottom, when applied to the `p` tag. But aligned when applied to `h` | On `p` tag is taller only when applied to 2nd+ row. Aligned on `h` tags and the 1st row of `p` | _Always aligned_ |
 | ![image](https://github.com/recogito/text-annotator-js/assets/68850090/252cc016-47b4-4f25-85bf-5c5dc0090e77) ![image](https://github.com/recogito/text-annotator-js/assets/68850090/25616adf-fa54-4004-a298-8fb274b20ba5) ![image](https://github.com/recogito/text-annotator-js/assets/68850090/ccbd07c5-09f6-44a6-821c-2d64911937db) | ![image](https://github.com/recogito/text-annotator-js/assets/68850090/5b4302d2-6868-4329-bccf-3d6eb9d24ba4) ![image](https://github.com/recogito/text-annotator-js/assets/68850090/b61e6dfb-e5a4-487f-939b-4b7cb261179f) ![image](https://github.com/recogito/text-annotator-js/assets/68850090/561eb4bc-f0f7-4271-bbaf-eae80252ba90) | ![image](https://github.com/recogito/text-annotator-js/assets/68850090/55abff94-bcfe-4eee-93f7-6b726831412a) ![image](https://github.com/recogito/text-annotator-js/assets/68850090/b78ec4b2-65f4-47db-82fd-8d1ee66d6065) ![image](https://github.com/recogito/text-annotator-js/assets/68850090/afbd3428-6fcb-42d8-8943-e84250387939) |




