### PR TITLE
Fixed nearly invisible text under saturated highlights

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.css
+++ b/packages/text-annotator/src/TextAnnotator.css
@@ -15,15 +15,6 @@ html, body {
   cursor: pointer;
 }
 
-.r6o-highlight-layer {
-  left: 0;
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  width: 100vw;
-  pointer-events: none;
-}
-
 *::selection, ::selection {
   background: rgba(0, 128, 255, 0.18);
 }

--- a/packages/text-annotator/src/highlight/canvas/canvasRenderer.css
+++ b/packages/text-annotator/src/highlight/canvas/canvasRenderer.css
@@ -1,0 +1,14 @@
+.r6o-highlight-layer {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    pointer-events: none;
+}
+
+.r6o-highlight-layer.bg {
+    z-index: 1;
+    mix-blend-mode: multiply;
+}

--- a/packages/text-annotator/src/highlight/canvas/canvasRenderer.css
+++ b/packages/text-annotator/src/highlight/canvas/canvasRenderer.css
@@ -9,6 +9,7 @@
 }
 
 .r6o-highlight-layer.bg {
-    z-index: 1;
+    /* Prevents fading out of the text */
     mix-blend-mode: multiply;
+    z-index: 1;
 }

--- a/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
+++ b/packages/text-annotator/src/highlight/canvas/canvasRenderer.ts
@@ -8,6 +8,8 @@ import type { Highlight } from '../Highlight';
 import type { TextAnnotatorState } from 'src/state';
 import type { ViewportState } from '@annotorious/core';
 
+import './canvasRenderer.css';
+
 const createCanvas = () => {
   const canvas = document.createElement('canvas');
   canvas.width = window.innerWidth;

--- a/packages/text-annotator/src/highlight/span/spansRenderer.css
+++ b/packages/text-annotator/src/highlight/span/spansRenderer.css
@@ -1,10 +1,10 @@
 .r6o-annotatable .r6o-span-highlight-layer {
-  height: 100%;
-  left: 0;
-  pointer-events: none;
   position: absolute;
   top: 0;
+  left: 0;
   width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 
 .r6o-annotatable .r6o-span-highlight-layer.hidden {
@@ -12,8 +12,8 @@
 }
 
 .r6o-annotatable .r6o-span-highlight-layer .r6o-annotation {
-  border-style: solid;
-  border-width: 0;
   position: absolute;
   display: block;
+  border-width: 0;
+  border-style: solid;
 }


### PR DESCRIPTION
### `CANVAS`
| `opacity` | Before | After |
|:--------:|:--------:|:--------:|
| 0.2 | ![image](https://github.com/recogito/text-annotator-js/assets/68850090/5f487e77-5a9c-45b3-b3e0-869230497d2c) | ![image](https://github.com/recogito/text-annotator-js/assets/68850090/74a5065e-2186-48b1-81b8-6f84c453e664) |
| 0.5 | ![image](https://github.com/recogito/text-annotator-js/assets/68850090/88919f7d-2e9e-4c59-aa51-fa30b422d698) | ![image](https://github.com/recogito/text-annotator-js/assets/68850090/45684a54-cda4-465d-97cc-2584fea46bd4) |
| 0.75 | ![image](https://github.com/recogito/text-annotator-js/assets/68850090/4d100562-9fe4-45fc-b043-71e98c16f18f) | ![image](https://github.com/recogito/text-annotator-js/assets/68850090/62a0bee4-1797-43b2-bc7d-09ec6f415830) |

### `SPANS`
Not problematic 👌🏻 

### `CSS_HIGHLIGHTS`
Not problematic 👌🏻 