### PR TITLE
Removed too broad `position: relative` CSS selector from global annotator styles

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.css
+++ b/packages/text-annotator/src/TextAnnotator.css
@@ -2,13 +2,11 @@ html, body {
   overscroll-behavior-y: none;
 }
 
-/* https://stackoverflow.com/questions/42507623/blue-highlight-on-onclick-on-buttons-in-chrome-mobile */
 .r6o-annotatable {
-  -webkit-tap-highlight-color: transparent;
-}
-
-.r6o-annotatable, .r6o-annotatable * {
   position: relative;
+
+  /* https://stackoverflow.com/questions/42507623/blue-highlight-on-onclick-on-buttons-in-chrome-mobile */
+  -webkit-tap-highlight-color: transparent;
 }
 
 .hovered * {


### PR DESCRIPTION
## Issue
When the `r6o-annotatable` container elements are critically dependent on the non-relative position - their selection acts unexpectedly on them. For example, `float: right/left` - users cannot select the floating element partially. Only as a whole while starting the selection before and finishing after it: 

https://github.com/user-attachments/assets/547dceea-4d38-420a-89d3-6108abb87dfd

https://github.com/user-attachments/assets/1c1cee41-498d-4901-8e9b-434abd07a2f1

Also, the positioning is broken for the popups, tooltips, etc, when their specificity is lower than the `.r6o-annotatable, .r6o-annotatable *`
![image](https://github.com/user-attachments/assets/f7668f51-9402-46ce-9cff-ce080bbe37cf)
![image](https://github.com/user-attachments/assets/fa2a5bca-2f34-41a8-8997-4e88cffe1177)

## Investigation
As I understood, the requirement of having the `position: relative` comes from the selection range rects coordinates normalization: https://github.com/recogito/text-annotator-js/blob/adf76b9b8c873f7945bcbcddfa5c3a42cf32e5bc/packages/text-annotator/src/state/spatialTree.ts#L48-L52
If we don't apply the `position: relative` to the content container - the highlights will be mispositioned:
![image](https://github.com/user-attachments/assets/92c4ffb3-ccc0-454f-98bf-e7635931206f)
![image](https://github.com/user-attachments/assets/1c67d81a-bf06-449e-a262-2d4130aecd57)

## Changes Made
Replaced the _too broad_ `.r6o-annotatable, .r6o-annotatable * {` selector with just the `.r6o-annotatable {`. It should be enough to properly position both the `span`/`canvas`-rendered highlights, but prevent positioning disruption for the content underneath.

## Demo

https://github.com/user-attachments/assets/9bb60449-70f9-42ca-b474-b8d31b9c4ae3

