### PR TITLE
Fixed dimmed text under saturated highlights while using `SPANS` renderer

### DIFF
--- a/packages/text-annotator/src/highlight/span/spansRenderer.css
+++ b/packages/text-annotator/src/highlight/span/spansRenderer.css
@@ -5,6 +5,8 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
+
+  mix-blend-mode: multiply;
 }
 
 .r6o-annotatable .r6o-span-highlight-layer.hidden {


### PR DESCRIPTION
## Issue
I noticed that while using the `SPANS` renderer, the text can look dim when you nest the highlights: 
![image](https://github.com/user-attachments/assets/f2779fe5-0a0b-4878-a2c4-3baed586b1de)


## Changes Made
The nature of the issues is the same as it was for the `CANVAS` renderer https://github.com/recogito/text-annotator-js/pull/114. Therefore, I just applied an appropriate `blend-mode` to the `spans` highlight layer:
![image](https://github.com/user-attachments/assets/f6c3cd70-71c6-4fb3-90a8-f3ec047cae9c)
