### PR TITLE
Renamed `annotationEnabled` -> `annotatingEnabled`

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -13,7 +13,7 @@ import {
 export const SelectionHandler = (
   container: HTMLElement,
   state: TextAnnotatorState,
-  annotationEnabled: boolean,
+  annotatingEnabled: boolean,
   offsetReferenceSelector?: string
 ) => {
 
@@ -53,7 +53,7 @@ export const SelectionHandler = (
     }
   }
 
-  if (annotationEnabled)
+  if (annotatingEnabled)
     container.addEventListener('selectstart', onSelectStart);
 
   const onSelectionChange = debounce((evt: PointerEvent) => {
@@ -110,7 +110,7 @@ export const SelectionHandler = (
     }
   })
 
-  if (annotationEnabled)
+  if (annotatingEnabled)
     document.addEventListener('selectionchange', onSelectionChange);
 
   // Select events don't carry information about the mouse button

--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -27,14 +27,14 @@ export interface TextAnnotator<E extends unknown = TextAnnotation> extends Annot
 }
 
 export const createTextAnnotator = <E extends unknown = TextAnnotation>(
-  container: HTMLElement, 
+  container: HTMLElement,
   options: TextAnnotatorOptions<E> = {}
 ): TextAnnotator<E> => {
   // Prevent mobile browsers from triggering word selection on single click.
   cancelSingleClickEvents(container);
 
   const opts = fillDefaults<E>(options, {
-    annotationEnabled: true
+    annotatingEnabled: true
   });
 
   const state: TextAnnotatorState = createTextAnnotatorState(container, opts.pointerAction);
@@ -46,18 +46,18 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
   const undoStack = createUndoStack(store);
 
   const lifecycle = createLifecycleObserver<TextAnnotation, E>(state, undoStack, opts.adapter);
-  
+
   let currentUser: User = createAnonymousGuest();
 
   // Use selected renderer, or fall back to default. If CSS_HIGHLIGHT is
   // requested, check if CSS Custom Highlights are supported, and fall
   // back to default renderer if not.
   const useRenderer: RendererType =
-    opts.renderer === 'CSS_HIGHLIGHTS' 
+    opts.renderer === 'CSS_HIGHLIGHTS'
       ? Boolean(CSS.highlights) ? 'CSS_HIGHLIGHTS' : USE_DEFAULT_RENDERER
       : opts.renderer || USE_DEFAULT_RENDERER;
 
-  const highlightRenderer = 
+  const highlightRenderer =
     useRenderer === 'SPANS' ? createSpansRenderer(container, state, viewport) :
     useRenderer === 'CSS_HIGHLIGHTS' ? createHighlightsRenderer(container, state, viewport) :
     useRenderer === 'CANVAS' ? createCanvasRenderer(container, state, viewport) : undefined;
@@ -66,11 +66,11 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
     throw `Unknown renderer implementation: ${useRenderer}`;
 
   console.debug(`Using ${useRenderer} renderer`);
-     
+
   if (opts.style)
     highlightRenderer.setStyle(opts.style);
 
-  const selectionHandler = SelectionHandler(container, state, opts.annotationEnabled, opts.offsetReferenceSelector);
+  const selectionHandler = SelectionHandler(container, state, opts.annotatingEnabled, opts.offsetReferenceSelector);
   selectionHandler.setUser(currentUser);
 
   /*************************/

--- a/packages/text-annotator/src/TextAnnotatorOptions.ts
+++ b/packages/text-annotator/src/TextAnnotatorOptions.ts
@@ -7,7 +7,7 @@ export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
 
   adapter?: FormatAdapter<TextAnnotation, T> | null;
 
-  annotationEnabled?: boolean;
+  annotatingEnabled?: boolean;
 
   renderer?: RendererType;
 
@@ -18,7 +18,7 @@ export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
   presence?: PresencePainterOptions;
 
   style?: HighlightStyleExpression;
-    
+
 }
 
 export type RendererType = 'SPANS' | 'CANVAS' | 'CSS_HIGHLIGHTS';
@@ -30,7 +30,7 @@ export const fillDefaults = <T extends unknown = TextAnnotation>  (
 
   return {
     ...opts,
-    annotationEnabled: opts.annotationEnabled === undefined ? defaults.annotationEnabled : opts.annotationEnabled
+    annotatingEnabled: opts.annotatingEnabled ?? defaults.annotatingEnabled
   };
 
 };

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -298,7 +298,7 @@
         var r = createTextAnnotator(contentContainer, {
           adapter: W3CTextFormat('https://www.gutenberg.org', contentContainer),
           renderer: 'SPANS',
-          // annotationEnabled: false,
+          // annotatingEnabled: false,
           style
         });
 


### PR DESCRIPTION
## Issue
I saw that the flag `annotationEnabled` is used only to enable "the selection and further creation of the annotations". All that workflow can be united under the _`annotating` umbrella **verb**_. 

## Changes Made
I renamed the `annotationEnabled` into the `annotatingEnabled`. IMHO, it defines the gated action more clearly. Instead, the `annotationEnabled` sounds too broad and makes me think that it'll disable rendering the annotations entirely.