### PR TITLE
Improve `userSelectAction` naming consistency

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -40,17 +40,11 @@ export const TextAnnotator = <E extends unknown>(props: TextAnnotatorProps<E>) =
     return () => anno.destroy();
   }, [setAnno]);
 
-  useEffect(() => {
-    if (!anno) return;
+  useEffect(() => anno?.setStyle(props.style), [anno, props.style]);
 
-    anno.setStyle(props.style);
-  }, [anno, props.style]);
+  useEffect(() => anno?.setFilter(props.filter), [anno, props.filter]);
 
-  useEffect(() => {
-    if (!anno) return;
-
-    anno.setFilter(props.filter);
-  }, [anno, props.filter]);
+  useEffect(() => anno?.setUserSelectAction(props.userSelectAction), [anno, props.userSelectAction]);
 
   return (
     <div ref={el} className={className}>

--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -37,7 +37,7 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
     annotatingEnabled: true
   });
 
-  const state: TextAnnotatorState = createTextAnnotatorState(container, opts.userAction);
+  const state: TextAnnotatorState = createTextAnnotatorState(container, opts.userSelectAction);
 
   const { selection, viewport } = state;
 

--- a/packages/text-annotator/src/TextAnnotatorOptions.ts
+++ b/packages/text-annotator/src/TextAnnotatorOptions.ts
@@ -13,7 +13,7 @@ export interface TextAnnotatorOptions<T extends unknown = TextAnnotation> {
 
   offsetReferenceSelector?: string;
 
-  userAction?: UserSelectActionExpression<TextAnnotation>,
+  userSelectAction?: UserSelectActionExpression<TextAnnotation>,
 
   presence?: PresencePainterOptions;
 

--- a/packages/text-annotator/src/state/TextAnnotatorState.ts
+++ b/packages/text-annotator/src/state/TextAnnotatorState.ts
@@ -28,14 +28,14 @@ export interface TextAnnotatorState extends AnnotatorState<TextAnnotation> {
 
 export const createTextAnnotatorState = (
   container: HTMLElement,
-  defaultUserAction?: UserSelectActionExpression<TextAnnotation>
+  defaultUserSelectAction?: UserSelectActionExpression<TextAnnotation>
 ): TextAnnotatorState => {
 
   const store: Store<TextAnnotation> = createStore<TextAnnotation>();
 
   const tree = createSpatialTree(store, container);
 
-  const selection = createSelectionState<TextAnnotation>(store, defaultUserAction);
+  const selection = createSelectionState<TextAnnotation>(store, defaultUserSelectAction);
 
   const hover = createHoverState(store);
 


### PR DESCRIPTION
## Issue
Across the parent [annotorious/annotorious](https://github.com/annotorious/annotorious) project we use the `userSelectAction` property name instead of just the `userAction`.
Moreover, changing that value on the React component didn't have any effect.