### PR TITLE
#127 Made `annotatingEnabled` property reactive

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -40,22 +40,16 @@ export const TextAnnotator = <E extends unknown>(props: TextAnnotatorProps<E>) =
     return () => anno.destroy();
   }, [setAnno]);
 
-  useEffect(() => {
-    if (!anno) return;
+  useEffect(() => anno?.setStyle(props.style), [anno, props.style]);
 
-    anno.setStyle(props.style);
-  }, [anno, props.style]);
+  useEffect(() => anno?.setFilter(props.filter), [anno, props.filter]);
 
-  useEffect(() => {
-    if (!anno) return;
-
-    anno.setFilter(props.filter);
-  }, [anno, props.filter]);
+  useEffect(() => anno?.setAnnotatingEnabled(props.annotatingEnabled), [anno, props.annotatingEnabled]);
 
   return (
     <div ref={el} className={className}>
       {children}
     </div>
-  )
+  );
 
 }

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -10,10 +10,9 @@ import {
   NOT_ANNOTATABLE_SELECTOR
 } from './utils';
 
-export const SelectionHandler = (
+export const createSelectionHandler = (
   container: HTMLElement,
   state: TextAnnotatorState,
-  annotatingEnabled: boolean,
   offsetReferenceSelector?: string
 ) => {
 
@@ -25,6 +24,10 @@ export const SelectionHandler = (
 
   const setFilter = (filter?: Filter) => currentFilter = filter;
 
+  let currentAnnotatingEnabled = true;
+
+  const setAnnotatingEnabled = (enabled: boolean) => currentAnnotatingEnabled = enabled;
+
   const { store, selection } = state;
 
   let currentTarget: TextAnnotationTarget | undefined;
@@ -34,6 +37,8 @@ export const SelectionHandler = (
   let lastPointerDown: PointerEvent | undefined;
 
   const onSelectStart = (evt: PointerEvent) => {
+    if (!currentAnnotatingEnabled) return;
+
     if (!isLeftClick) return;
 
     // Make sure we don't listen to selection changes that were
@@ -53,10 +58,11 @@ export const SelectionHandler = (
     }
   }
 
-  if (annotatingEnabled)
-    container.addEventListener('selectstart', onSelectStart);
+  container.addEventListener('selectstart', onSelectStart);
 
   const onSelectionChange = debounce((evt: PointerEvent) => {
+    if (!currentAnnotatingEnabled) return;
+
     const sel = document.getSelection();
 
     // This is to handle cases where the selection is "hijacked" by another element
@@ -110,8 +116,7 @@ export const SelectionHandler = (
     }
   })
 
-  if (annotatingEnabled)
-    document.addEventListener('selectionchange', onSelectionChange);
+  document.addEventListener('selectionchange', onSelectionChange);
 
   // Select events don't carry information about the mouse button
   // Therefore, to prevent right-click selection, we need to listen
@@ -170,7 +175,8 @@ export const SelectionHandler = (
   return {
     destroy,
     setFilter,
-    setUser
+    setUser,
+    setAnnotatingEnabled
   }
 
 }


### PR DESCRIPTION
## Issue - https://github.com/recogito/text-annotator-js/issues/127

## Changes Made
I made the `annotatingEnabled` a dynamic property that can receive values from the external sources via the `setAnnotatingEnabled` (following the ["
API addition: method to change userSelectAction"](https://github.com/annotorious/annotorious/commit/1daff59d1bf7e07df3a27620f131a3def52e1d60) example)