### PR TITLE
#130 Added `recalculation` completion listener to the `spatialTree`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3132,6 +3132,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/nanoevents/-/nanoevents-9.0.0.tgz",
       "integrity": "sha512-X8pU7IOpgKXVLPxYUI55ymXc8XuBE+uypfEyEFBtHkD1EX9KavYTVc+vXZHFyHKzA1TaZoVDqklLdQBBrxIuAw==",
+      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
@@ -4371,6 +4372,7 @@
         "@annotorious/core": "^3.0.0-rc.31",
         "colord": "^2.9.3",
         "dequal": "^2.0.3",
+        "nanoevents": "^9.0.0",
         "rbush": "^4.0.0",
         "uuid": "^10.0.0"
       },

--- a/packages/text-annotator/package.json
+++ b/packages/text-annotator/package.json
@@ -40,6 +40,7 @@
     "@annotorious/core": "^3.0.0-rc.31",
     "colord": "^2.9.3",
     "dequal": "^2.0.3",
+    "nanoevents": "^9.0.0",
     "rbush": "^4.0.0",
     "uuid": "^10.0.0"
   }

--- a/packages/text-annotator/src/state/TextAnnotationStore.ts
+++ b/packages/text-annotator/src/state/TextAnnotationStore.ts
@@ -1,5 +1,9 @@
+import type { Unsubscribe } from 'nanoevents';
 import type { Filter, Origin, Store } from '@annotorious/core';
+
 import type { TextAnnotation } from '../model';
+import type { SpatialTreeEvents } from './spatialTree';
+
 
 export interface TextAnnotationStore extends Omit<Store<TextAnnotation>, 'addAnnotation' | 'bulkAddAnnotation'> {
 
@@ -18,6 +22,8 @@ export interface TextAnnotationStore extends Omit<Store<TextAnnotation>, 'addAnn
   getIntersecting(minX: number, minY: number, maxX: number, maxY: number): AnnotationRects[];
 
   recalculatePositions(): void;
+
+  onRecalculatePositions(callback: SpatialTreeEvents['recalculate']): Unsubscribe;
 
 }
 

--- a/packages/text-annotator/src/state/TextAnnotatorState.ts
+++ b/packages/text-annotator/src/state/TextAnnotatorState.ts
@@ -9,7 +9,7 @@ import {
   Origin,
   createViewportState
 } from '@annotorious/core';
-import { createSpatialTree } from './spatialTree';
+import { createSpatialTree, type SpatialTreeEvents } from './spatialTree';
 import type { TextAnnotation, TextAnnotationTarget } from '../model';
 import type { TextAnnotationStore } from './TextAnnotationStore';
 import { isRevived, reviveAnnotation, reviveTarget } from '../utils';
@@ -129,6 +129,7 @@ export const createTextAnnotatorState = (
   }
 
   const recalculatePositions = () => tree.recalculate();
+  const onRecalculatePositions = (callback: SpatialTreeEvents['recalculate']) => tree.on('recalculate', callback);
 
   store.observe(({ changes }) => {
     const deleted = (changes.deleted || []).filter(a => isRevived(a.target.selector));
@@ -156,6 +157,7 @@ export const createTextAnnotatorState = (
       getAt,
       getIntersecting: tree.getIntersecting,
       recalculatePositions,
+      onRecalculatePositions,
       updateTarget
     },
     selection,

--- a/packages/text-annotator/src/state/spatialTree.ts
+++ b/packages/text-annotator/src/state/spatialTree.ts
@@ -1,5 +1,7 @@
 import RBush from 'rbush';
 import type { Store } from '@annotorious/core';
+import { createNanoEvents, type Unsubscribe } from 'nanoevents';
+
 import type { TextAnnotation, TextAnnotationTarget } from '../model';
 import { isRevived, mergeClientRects } from '../utils';
 import { getClientRectsPonyfill } from '../utils/getClientRectsPonyfill';
@@ -30,11 +32,19 @@ interface IndexedHighlightRect {
 
 }
 
+export interface SpatialTreeEvents {
+
+  recalculate(): void;
+
+}
+
 export const createSpatialTree = (store: Store<TextAnnotation>, container: HTMLElement) => {
 
   const tree = new RBush<IndexedHighlightRect>();
 
   const index = new Map<string, IndexedHighlightRect[]>();
+
+  const emitter = createNanoEvents<SpatialTreeEvents>();
 
   // Helper: converts a single text annotation target to a list of hightlight rects
   const toItems = (target: TextAnnotationTarget, offset: DOMRect): IndexedHighlightRect[] => {
@@ -184,8 +194,12 @@ export const createSpatialTree = (store: Store<TextAnnotation>, container: HTMLE
 
   const size = () => tree.all().length;
 
-  const recalculate = () =>
+  const recalculate = () => {
     set(store.all().map(a => a.target), true);
+    emitter.emit('recalculate');
+  };
+
+  const on = <E extends keyof SpatialTreeEvents>(event: E, callback: SpatialTreeEvents[E]): Unsubscribe => emitter.on(event, callback);
 
   return {
     all,
@@ -199,7 +213,8 @@ export const createSpatialTree = (store: Store<TextAnnotation>, container: HTMLE
     remove,
     set,
     size,
-    update
+    update,
+    on
   }
 
 }


### PR DESCRIPTION
## Issue - https://github.com/recogito/text-annotator-js/issues/130

## Changes Made
Following the [`UndoStack`](https://github.com/annotorious/annotorious/blob/main/packages/annotorious-core/src/state/UndoStack.ts) example from A9S, I added the `nanoevents` emitter to the `spatialTree`. 
Currently, we're interested in just a single event type - `recalculated`. Which fires upon the completion of the `recalculate` function