### PR TITLE
#133 Fixed missing annotation dismissal clicking outside of the annotator `container`

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -124,7 +124,7 @@ export const SelectionHandler = (
     isLeftClick = evt.button === 0;
   }
 
-  container.addEventListener('pointerdown', onPointerDown);
+  document.addEventListener('pointerdown', onPointerDown);
 
   const onPointerUp = (evt: PointerEvent) => {
     const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
@@ -135,7 +135,11 @@ export const SelectionHandler = (
     const clickSelect = () => {
       const { x, y } = container.getBoundingClientRect();
 
-      const hovered = store.getAt(evt.clientX - x, evt.clientY - y, currentFilter);
+      const hovered =
+        evt.target instanceof Node &&
+        container.contains(evt.target) &&
+        store.getAt(evt.clientX - x, evt.clientY - y, currentFilter);
+
       if (hovered) {
         const { selected } = selection;
 
@@ -163,7 +167,7 @@ export const SelectionHandler = (
     container.removeEventListener('selectstart', onSelectStart);
     document.removeEventListener('selectionchange', onSelectionChange);
     
-    container.removeEventListener('pointerdown', onPointerDown);
+    document.removeEventListener('pointerdown', onPointerDown);
     document.removeEventListener('pointerup', onPointerUp);
   }
 


### PR DESCRIPTION
## Issue - https://github.com/recogito/text-annotator-js/issues/133

## Changes Made
To capture the actual `lastPointerDown` event on the page and make the correct `timeDifference` calculations, I added `pointerdown` event to the `document` scope.

In that way, the "click" will be properly recognized in the `pointerup` handler and the selection will be dismissed. As there will be no annotation under the pointer.