### PR TITLE
#136 Fixed missing annotation dismissal clicking over native selection range

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -158,10 +158,10 @@ export const SelectionHandler = (
      * @see https://github.com/recogito/text-annotator-js/issues/136
      */
     setTimeout(() => {
-      const { isCollapsed } = document.getSelection()
+      const sel = document.getSelection()
 
       // Just a click, not a selection
-      if (isCollapsed && timeDifference < 300) {
+      if (sel?.isCollapsed && timeDifference < 300) {
         currentTarget = undefined;
         clickSelect();
       } else if (currentTarget) {


### PR DESCRIPTION
## Issue - https://github.com/recogito/text-annotator-js/issues/136

## Changes Made
Added timeout before reading the `document.getSelection().isCollapsed`, making it more consistent, and eliminating the difference between clicking over the native selection range and beyond it. See more details [here](https://arc.net/l/quote/aljeqjqs).

## Demo

https://github.com/user-attachments/assets/5f49da4e-341d-4811-902c-91cdeb479168
