### PR TITLE
Added default `z-index` for the span highlights

### DIFF
--- a/packages/text-annotator/src/highlight/span/spansRenderer.css
+++ b/packages/text-annotator/src/highlight/span/spansRenderer.css
@@ -1,11 +1,12 @@
 .r6o-annotatable .r6o-span-highlight-layer {
-  height: 100%;
-  left: 0;
-  mix-blend-mode: multiply;
-  pointer-events: none;
   position: absolute;
   top: 0;
+  left: 0;
   width: 100%;
+  height: 100%;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+  z-index: 1;
 }
 
 .r6o-annotatable .r6o-span-highlight-layer.hidden {


### PR DESCRIPTION
## Issue
The `SPAN`'s `.r6o-span-highlight-layer` should be brought up above the regular textual content on the page. That will prevent elements with the background from being displayed over the highlights.

## Example
| W/o `z-index` | W/ `z-index: 1` |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/005d0118-2f48-4a0f-9394-7e6b93abe705) | ![image](https://github.com/user-attachments/assets/e4bf5654-f6e2-488b-832d-f74c768fa03b) | 


## Changes Made
Added `z-index: 1` to put the `.r6o-span-highlight-layer` out of the nesting stack. Similar treatment has already been done to the canvas: 
https://github.com/recogito/text-annotator-js/blob/e6d3f33339ab1f4cd2ccb6b77624c20f12841ee4/packages/text-annotator/src/highlight/canvas/canvasRenderer.css#L11-L14
