### PR TITLE
Fixed popup content props usage

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup.tsx
@@ -19,7 +19,7 @@ interface TextAnnotationPopupProps {
 
 }
 
-interface TextAnnotationPopupContentProps {
+export interface TextAnnotationPopupContentProps {
 
   annotation: TextAnnotation;
   

--- a/packages/text-annotator-react/test/App.tsx
+++ b/packages/text-annotator-react/test/App.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { AnnotationBody, Annotorious, useAnnotationStore, useAnnotator } from '@annotorious/react';
-import { TextAnnotator, TextAnnotatorPopup, TextAnnotatorPopupProps } from '../src';
-import { TextAnnotation, TextAnnotator as RecogitoTextAnnotator, W3CTextFormat } from '@recogito/text-annotator';
+import { TextAnnotator, TextAnnotatorPopup, type TextAnnotationPopupContentProps } from '../src';
+import { W3CTextFormat, type TextAnnotation, type TextAnnotator as RecogitoTextAnnotator } from '@recogito/text-annotator';
 
-const TestPopup = (props: TextAnnotatorPopupProps) => {
+const TestPopup = (props: TextAnnotationPopupContentProps) => {
 
   const store = useAnnotationStore();
   const anno = useAnnotator<RecogitoTextAnnotator>();
@@ -12,7 +12,7 @@ const TestPopup = (props: TextAnnotatorPopupProps) => {
 
   const body: AnnotationBody = {
     id: `${Math.random()}`,
-    annotation: props.selected[0].annotation.id,
+    annotation: props.annotation.id,
     purpose: 'commenting',
     value: 'A Dummy Comment'
   };

--- a/packages/text-annotator-react/test/index.html
+++ b/packages/text-annotator-react/test/index.html
@@ -24,6 +24,10 @@
         line-height: 160%;
       }
 
+      .annotation-popup {
+        z-index: 1;
+      }
+
       .popup {
         background-color: #fff;
         border: 1px solid gray;

--- a/packages/text-annotator-react/test/tei/App.tsx
+++ b/packages/text-annotator-react/test/tei/App.tsx
@@ -3,9 +3,9 @@ import React, { useEffect, useRef, useState } from 'react';
 import { AnnotationBody, Annotorious, useAnnotationStore, useAnnotator } from '@annotorious/react';
 import { TextAnnotation, TextAnnotator as VanillaTextAnnotator } from '@recogito/text-annotator';
 
-import { TEIAnnotator, CETEIcean, TextAnnotatorPopup, TextAnnotatorPopupProps } from '../../src';
+import { TEIAnnotator, CETEIcean, TextAnnotatorPopup, type TextAnnotationPopupContentProps } from '../../src';
 
-const TestPopup = (props: TextAnnotatorPopupProps) => {
+const TestPopup = (props: TextAnnotationPopupContentProps) => {
 
   const store = useAnnotationStore();
   const anno = useAnnotator<VanillaTextAnnotator>();
@@ -14,7 +14,7 @@ const TestPopup = (props: TextAnnotatorPopupProps) => {
 
   const body: AnnotationBody = {
     id: `${Math.random()}`,
-    annotation: props.selected[0].annotation.id,
+    annotation: props.annotation.id,
     purpose: 'commenting',
     value: 'A Dummy Comment'
   };

--- a/packages/text-annotator-react/test/tei/index.html
+++ b/packages/text-annotator-react/test/tei/index.html
@@ -33,6 +33,10 @@
         line-height: 160%;
       }
 
+      .annotation-popup {
+        z-index: 1;
+      }
+
       .popup {
         background-color: #fff;
         border: 1px solid gray;


### PR DESCRIPTION
## Issue
In https://github.com/recogito/text-annotator-js/commit/7fafa46a8c3522753c9cace1027c4f02369d9a32 the interface of the `TextAnnotatorPopup` content props got updated in correspondence to the image popup. 
However, the test files were not updated along and it led to the exceptions when you try running the `text-annotator-react` examples on `main`.