### PR TITLE
#147 Fixed unexpected selection dismissal on dragging from `input`/`textarea` to browser's toolbar

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -124,7 +124,9 @@ export const SelectionHandler = (
   }
 
   const onPointerUp = (evt: PointerEvent) => {
-    const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
+    const evtTarget = evt.target as Node;
+
+    const annotatable = !evtTarget.parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
     if (!annotatable || !isLeftClick)
       return;
 
@@ -159,12 +161,25 @@ export const SelectionHandler = (
      * @see https://github.com/recogito/text-annotator-js/issues/136
      */
     setTimeout(() => {
-      const sel = document.getSelection()
+      const sel = document.getSelection();
 
       // Just a click, not a selection
       if (sel?.isCollapsed && timeDifference < 300) {
-        currentTarget = undefined;
-        clickSelect();
+
+        /**
+         * Don't process the collapsed range as the click
+         * when it ends on the document root element, `html`.
+         *
+         * It can happen when user quickly drags from the
+         * `input`/`textarea` to the browser's toolbar.
+         *
+         * @see https://github.com/recogito/text-annotator-js/issues/147
+         */
+        if (evtTarget !== document.documentElement) {
+          currentTarget = undefined;
+          clickSelect();
+        }
+
       } else if (currentTarget) {
         selection.userSelect(currentTarget.annotation, evt);
       }


### PR DESCRIPTION
## Issue - https://github.com/recogito/text-annotator-js/issues/147

## Changes Made
Added target check that prevents handling the ephemeral "click" event when the `pointerup` lands on the root of the page, `html` element. In that way, the user won't be able to accidentally dismiss the selection while rapidly dragging from the `input`/`textarea` to the browser's controls.

## Demo

https://github.com/user-attachments/assets/f13c0fe3-ebed-464e-a8a9-157e8f9b5c0b

