### PR TITLE
#133 Fixed missing annotation dismissal clicking outside of the annotator `container` (vol.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3557,9 +3557,9 @@
       }
     },
     "node_modules/openseadragon": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/openseadragon/-/openseadragon-5.0.0.tgz",
-      "integrity": "sha512-S9aabSjmJg7Jfow1UItR5aXiKQLtkDWyRR5fxLeqT4vSYMvfscXUDfVS9snUN3JuIrHaSPJAlR4H2DYSn5DWRg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/openseadragon/-/openseadragon-4.1.1.tgz",
+      "integrity": "sha512-owU9gsasAcobLN+LM8lN58Xc2VDSDotY9mkrwS/NB6g9KX/PcusV4RZvhHng2RF/Q0pMziwldf62glwXoGnuzg==",
       "license": "BSD-3-Clause",
       "peer": true,
       "funding": {

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -171,7 +171,7 @@ export const SelectionHandler = (
     });
   }
 
-  container.addEventListener('pointerdown', onPointerDown);
+  document.addEventListener('pointerdown', onPointerDown);
   document.addEventListener('pointerup', onPointerUp);
 
   if (annotatingEnabled) {
@@ -180,7 +180,7 @@ export const SelectionHandler = (
   }
 
   const destroy = () => {
-    container.removeEventListener('pointerdown', onPointerDown);
+    document.removeEventListener('pointerdown', onPointerDown);
     document.removeEventListener('pointerup', onPointerUp);
 
     container.removeEventListener('selectstart', onSelectStart);

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -116,6 +116,9 @@ export const SelectionHandler = (
   // Therefore, to prevent right-click selection, we need to listen
   // to the initial pointerdown event and remember the button
   const onPointerDown = (evt: PointerEvent) => {
+    const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
+    if (!annotatable) return;
+
     // Note that the event itself can be ephemeral!
     const { target, timeStamp, offsetX, offsetY, type } = evt;
     lastPointerDown = { ...evt, target, timeStamp, offsetX, offsetY, type };
@@ -125,8 +128,7 @@ export const SelectionHandler = (
 
   const onPointerUp = (evt: PointerEvent) => {
     const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
-    if (!annotatable || !isLeftClick)
-      return;
+    if (!annotatable || !isLeftClick) return;
 
     // Logic for selecting an existing annotation by clicking it
     const clickSelect = () => {


### PR DESCRIPTION
Issue - https://github.com/recogito/text-annotator-js/issues/133

## Changes Made 
To capture the actual `lastPointerDown` event on the page and make the correct `timeDifference` calculations, I added `pointerdown` event to the `document` scope.

In that way, the "click" will be properly recognized in the `pointerup` handler and the selection will be dismissed. As there will be no annotation under the pointer.

---

However, we should capture the `pointerdown` only on the elements that are not located within the`not-annotatable` tree! Otherwise, it would be possible to unexpectedly dismiss the selected annotation while a user quickly drags from the `input`/`textarea`/`button`, etc. onto the textual content!
More details with demo - https://github.com/recogito/text-annotator-js/pull/135#issuecomment-2327121736