### PR TITLE
Revised Selection Behavior

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.css
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.css
@@ -3,7 +3,7 @@
  * or the screen reader users as the popup behavior hint
  * Inspired by https://gist.github.com/ffoodd/000b59f431e3e64e4ce1a24d5bb36034
  */
-.popup-close-message {
+.r6o-popup-sr-only {
   border: 0 !important;
   clip: rect(1px, 1px, 1px, 1px);
   -webkit-clip-path: inset(50%);
@@ -17,8 +17,8 @@
   white-space: nowrap;
 }
 
-.popup-close-message:focus,
-.popup-close-message:active {
+.r6o-popup-sr-only:focus,
+.r6o-popup-sr-only:active {
   clip: auto;
   -webkit-clip-path: none;
   clip-path: none;

--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -1,4 +1,6 @@
-import React, { PointerEvent, ReactNode, useCallback, useEffect, useState } from 'react';
+import { PointerEvent, ReactNode, useCallback, useEffect, useState } from 'react';
+import { useAnnotator, useSelection } from '@annotorious/react';
+import type { TextAnnotation, TextAnnotator } from '@recogito/text-annotator';
 import {
   autoUpdate,
   flip,
@@ -12,9 +14,6 @@ import {
   useInteractions,
   useRole
 } from '@floating-ui/react';
-
-import { useAnnotator, useSelection } from '@annotorious/react';
-import type { TextAnnotation, TextAnnotator } from '@recogito/text-annotator';
 
 import './TextAnnotatorPopup.css';
 
@@ -162,4 +161,4 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
     </FloatingPortal>
   ) : null;
 
-};
+}

--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -73,12 +73,13 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
   const { getFloatingProps } = useInteractions([dismiss, role]);
 
   const selectedKey = selected.map(a => a.annotation.id).join('-');
+
   useEffect(() => {
     // Ignore all selection changes except those accompanied by a user event.
-    if (selected.length > 0 && event) {
-      setOpen(event.type === 'pointerup' || event.type === 'keydown');
+    if (selected.length > 0) { // && event) {
+      setOpen(true); // event.type === 'pointerup' || event.type === 'keydown');
     }
-  }, [selectedKey, event]);
+  }, [selectedKey /*, event */]);
 
   useEffect(() => {
     // Close the popup if the selection is cleared

--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -1,11 +1,13 @@
-import { ReactNode, useCallback, useEffect, useState, PointerEvent } from 'react';
+import { PointerEvent, ReactNode, useCallback, useEffect, useState } from 'react';
 import { useAnnotator, useSelection } from '@annotorious/react';
-import { type TextAnnotation, type TextAnnotator } from '@recogito/text-annotator';
+import type { TextAnnotation, TextAnnotator } from '@recogito/text-annotator';
 import {
   autoUpdate,
+  flip,
+  FloatingFocusManager,
+  FloatingPortal,
   inline,
   offset,
-  flip,
   shift,
   useDismiss,
   useFloating,
@@ -13,16 +15,20 @@ import {
   useRole
 } from '@floating-ui/react';
 
+import './TextAnnotatorPopup.css';
+
 interface TextAnnotationPopupProps {
+
+  ariaCloseWarning?: string;
 
   popup(props: TextAnnotationPopupContentProps): ReactNode;
 
 }
 
-interface TextAnnotationPopupContentProps {
+export interface TextAnnotationPopupContentProps {
 
   annotation: TextAnnotation;
-  
+
   editable?: boolean;
 
   event?: PointerEvent;
@@ -33,7 +39,7 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
 
   const r = useAnnotator<TextAnnotator>();
 
-  const { selected } = useSelection<TextAnnotation>();
+  const { selected, event } = useSelection<TextAnnotation>();
 
   const annotation = selected[0]?.annotation;
 
@@ -42,12 +48,14 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
   const { refs, floatingStyles, update, context } = useFloating({
     placement: 'top',
     open: isOpen,
-    /* onOpenChange: (open, _event, reason) => {
+    onOpenChange: (open, _event, reason) => {
       setOpen(open);
-      if (!open && reason === 'escape-key') {
-        r?.cancelSelected();
+
+      if (!open) {
+        if (reason === 'escape-key' || reason === 'focus-out')
+          r?.cancelSelected();
       }
-    }, */
+    },
     middleware: [
       offset(10),
       inline(),
@@ -59,32 +67,29 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
 
   const dismiss = useDismiss(context);
 
-  const role = useRole(context, { role: 'tooltip' });
-  
+  const role = useRole(context, { role: 'dialog' });
+
   const { getFloatingProps } = useInteractions([dismiss, role]);
 
-  const selectedKey = selected.map(a => a.annotation.id).join('-');
-
   useEffect(() => {
-    // Ignore all selection changes except those accompanied by a pointer event.
     setOpen(selected.length > 0);
-  }, [selectedKey]);
+  }, [selected.map(a => a.annotation.id).join('-')]);
 
   useEffect(() => {
-    if (!isOpen || !annotation) return;
+    if (isOpen && annotation) {
+      const {
+        target: {
+          selector: [{ range }]
+        }
+      } = annotation;
 
-    if (!annotation.target.selector || annotation.target.selector.length === 0) return;
-
-    const {
-      target: {
-        selector: [{ range }]
-      }
-    } = annotation;
-
-    refs.setPositionReference({
-      getBoundingClientRect: () => range.getBoundingClientRect(),
-      getClientRects:() => range.getClientRects()
-    });
+      refs.setPositionReference({
+        getBoundingClientRect: () => range.getBoundingClientRect(),
+        getClientRects: () => range.getClientRects()
+      });
+    } else {
+      refs.setPositionReference(null);
+    }
   }, [isOpen, annotation, refs]);
 
   // Prevent text-annotator from handling the irrelevant events triggered from the popup
@@ -104,21 +109,38 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
     return () => {
       mutationObserver.disconnect();
       window.document.removeEventListener('scroll', update, true);
-    }
+    };
   }, [update]);
 
   return isOpen && selected.length > 0 ? (
-    <div
-      className="annotation-popup text-annotation-popup not-annotatable"
-      ref={refs.setFloating}
-      style={floatingStyles}
-      {...getFloatingProps()}
-      {...getStopEventsPropagationProps()}>
-      {props.popup({
-        annotation: selected[0].annotation,
-        editable: selected[0].editable
-       })}
-    </div>
+    <FloatingPortal>
+      <FloatingFocusManager
+        context={context}
+        modal={false}
+        closeOnFocusOut={true}
+        returnFocus={false}
+        initialFocus={
+          // Don't shift focus to the floating element when selected via keyboard
+          event?.type === 'keydown' ? -1 : 0
+        }>
+        <div
+          className="annotation-popup text-annotation-popup not-annotatable"
+          ref={refs.setFloating}
+          style={floatingStyles}
+          {...getFloatingProps()}
+          {...getStopEventsPropagationProps()}>
+          {props.popup({
+            annotation: selected[0].annotation,
+            editable: selected[0].editable,
+            event
+          })}
+
+          <span className="r6o-popup-sr-only" aria-live="assertive">
+            {props.ariaCloseWarning || 'This dialog will close when you leave it.'}
+          </span>
+        </div>
+      </FloatingFocusManager>
+    </FloatingPortal>
   ) : null;
 
 }

--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -122,9 +122,8 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
         closeOnFocusOut={true}
         returnFocus={false}
         initialFocus={
-          // Don't shift focus to the floating element if selected via keyboard
-          // or on iPad/Android.
-          (event?.type === 'keydown' || isMobile()) ? -1 : 0
+          // Don't shift focus to the floating element if selected via keyboard or on mobile.
+          (event?.type === 'keydown' || event?.type === 'contextmenu' || isMobile()) ? -1 : 0
         }>
         <div
           className="annotation-popup text-annotation-popup not-annotatable"

--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -1,4 +1,4 @@
-import { PointerEvent, ReactNode, useCallback, useEffect, useState } from 'react';
+import { PointerEvent, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAnnotator, useSelection } from '@annotorious/react';
 import type { TextAnnotation, TextAnnotator } from '@recogito/text-annotator';
 import { isMobile } from './isMobile';
@@ -114,6 +114,11 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
     };
   }, [update]);
 
+  // Don't shift focus to the floating element if selected via keyboard or on mobile.
+  const initialFocus = useMemo(() => {
+    return (event?.type === 'keyup' || event?.type === 'contextmenu' || isMobile()) ? -1 : 0;
+  }, [event]);
+
   return isOpen && selected.length > 0 ? (
     <FloatingPortal>
       <FloatingFocusManager
@@ -121,10 +126,7 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
         modal={false}
         closeOnFocusOut={true}
         returnFocus={false}
-        initialFocus={
-          // Don't shift focus to the floating element if selected via keyboard or on mobile.
-          (event?.type === 'keydown' || event?.type === 'contextmenu' || isMobile()) ? -1 : 0
-        }>
+        initialFocus={initialFocus}>
         <div
           className="annotation-popup text-annotation-popup not-annotatable"
           ref={refs.setFloating}

--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -94,12 +94,6 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
     }
   }, [isOpen, annotation, refs]);
 
-  // Prevent text-annotator from handling the irrelevant events triggered from the popup
-  const getStopEventsPropagationProps = useCallback(
-    () => ({ onPointerUp: (event: PointerEvent<HTMLDivElement>) => event.stopPropagation() }),
-    []
-  );
-
   useEffect(() => {
     const config: MutationObserverInit = { attributes: true, childList: true, subtree: true };
 
@@ -114,10 +108,18 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
     };
   }, [update]);
 
+  // Prevent text-annotator from handling the irrelevant events triggered from the popup
+  const getStopEventsPropagationProps = useCallback(
+    () => ({ onPointerUp: (event: PointerEvent<HTMLDivElement>) => event.stopPropagation() }),
+    []
+  );
+
   // Don't shift focus to the floating element if selected via keyboard or on mobile.
   const initialFocus = useMemo(() => {
     return (event?.type === 'keyup' || event?.type === 'contextmenu' || isMobile()) ? -1 : 0;
   }, [event]);
+
+  const onClose = () => r?.cancelSelected();
 
   return isOpen && selected.length > 0 ? (
     <FloatingPortal>
@@ -139,9 +141,9 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
             event
           })}
 
-          <span className="r6o-popup-sr-only" aria-live="assertive">
-            {props.ariaCloseWarning || 'This dialog will close when you leave it.'}
-          </span>
+          <button className="r6o-popup-sr-only" aria-live="assertive" onClick={onClose}>
+            {props.ariaCloseWarning || 'Click or leave this dialog to close it.'}
+          </button>
         </div>
       </FloatingFocusManager>
     </FloatingPortal>

--- a/packages/text-annotator-react/src/TextAnnotatorPopup/isMobile.ts
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/isMobile.ts
@@ -1,0 +1,17 @@
+// https://stackoverflow.com/questions/21741841/detecting-ios-android-operating-system
+export const isMobile = () => {
+  // @ts-ignore
+  var userAgent: string = navigator.userAgent || navigator.vendor || window.opera;
+
+  if (/android/i.test(userAgent)) 
+    return true;
+
+  // @ts-ignore
+  // Note: as of recently, this NO LONGER DETECTS FIREFOX ON iOS!
+  // This means FF/iOS will behave like on the desktop, and loose
+  // selection handlebars after the popup opens.
+  if (/iPad|iPhone/.test(userAgent) && !window.MSStream)
+    return true;
+
+  return false;
+}

--- a/packages/text-annotator-react/test/App.tsx
+++ b/packages/text-annotator-react/test/App.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useCallback, useEffect } from 'react';
 import { AnnotationBody, Annotorious, useAnnotationStore, useAnnotator, useSelection } from '@annotorious/react';
-import { TextAnnotator, TextAnnotatorPopup, type TextAnnotationPopupContentProps } from '../src';
+import { TextAnnotator, TextAnnotatorPopup } from '../src';
 import { W3CTextFormat, type TextAnnotation, type TextAnnotator as RecogitoTextAnnotator } from '@recogito/text-annotator';
 
-const TestPopup: FC<TextAnnotationPopupContentProps> = (props) => {
+const TestPopup = (props) => {
 
   const { annotation } = props;
 

--- a/packages/text-annotator-react/test/App.tsx
+++ b/packages/text-annotator-react/test/App.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useCallback, useEffect } from 'react';
-import { AnnotationBody, Annotorious, useAnnotationStore, useAnnotator, useSelection } from '@annotorious/react';
-import { TextAnnotator, TextAnnotatorPopup } from '../src';
+import { AnnotationBody, Annotorious, useAnnotationStore, useAnnotator } from '@annotorious/react';
+import { TextAnnotationPopupContentProps, TextAnnotator, TextAnnotatorPopup } from '../src';
 import { W3CTextFormat, type TextAnnotation, type TextAnnotator as RecogitoTextAnnotator } from '@recogito/text-annotator';
 
-const TestPopup = (props) => {
+const TestPopup: FC<TextAnnotationPopupContentProps> = (props) => {
 
   const { annotation } = props;
 

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -92,13 +92,11 @@ export const SelectionHandler = (
 
         // Chrome/iOS does not reliably fire the 'selectstart' event!
         onSelectStart(lastDownEvent || evt);
-
       } else if (sel.isCollapsed && timeDifference < CLICK_TIMEOUT) {
 
         // Firefox doesn't fire the 'selectstart' when user clicks
         // over the text, which collapses the selection
         onSelectStart(lastDownEvent || evt);
-
       }
     }
 
@@ -209,17 +207,45 @@ export const SelectionHandler = (
         // Proper lifecycle management: clear selection first...
         selection.clear();
 
-        // ...then add annotation to store...
-        store.addAnnotation({
-          id: currentTarget.annotation,
-          bodies: [],
-          target: currentTarget
-        });
+        const exists = store.getAnnotation(currentTarget.annotation);
+        if (exists) {
+          // ...then add annotation to store...
+          store.updateTarget(currentTarget);
+        } else {
+          // ...then add annotation to store...
+          store.addAnnotation({
+            id: currentTarget.annotation,
+            bodies: [],
+            target: currentTarget
+          });
+        }
 
         // ...then make the new annotation the current selection
         selection.userSelect(currentTarget.annotation, clonePointerEvent(evt));
       }
     });
+  }
+
+  const onContextMenu = (evt: PointerEvent) => {
+    const sel = document.getSelection();
+    if (sel?.isCollapsed) return;
+
+    // selection.clear();
+
+    const exists = store.getAnnotation(currentTarget.annotation);
+    if (exists) {
+      // ...then add annotation to store...
+      store.updateTarget(currentTarget);
+    } else {
+      // ...then add annotation to store...
+      store.addAnnotation({
+        id: currentTarget.annotation,
+        bodies: [],
+        target: currentTarget
+      });
+    }
+
+    selection.userSelect(currentTarget.annotation, clonePointerEvent(evt));
   }
 
   const onKeyup = (evt: KeyboardEvent) => {
@@ -297,7 +323,7 @@ export const SelectionHandler = (
 
   container.addEventListener('pointerdown', onPointerDown);
   document.addEventListener('pointerup', onPointerUp);
-  document.addEventListener('contextmenu', onPointerUp);
+  document.addEventListener('contextmenu', onContextMenu);
 
   if (annotatingEnabled) {
     container.addEventListener('keyup', onKeyup);
@@ -308,7 +334,7 @@ export const SelectionHandler = (
   const destroy = () => {
     container.removeEventListener('pointerdown', onPointerDown);
     document.removeEventListener('pointerup', onPointerUp);
-    document.removeEventListener('contextmenu', onPointerUp);
+    document.removeEventListener('contextmenu', onContextMenu);
 
     container.removeEventListener('keyup', onKeyup);
     container.removeEventListener('selectstart', onSelectStart);

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -266,24 +266,30 @@ export const SelectionHandler = (
   }
 
   const onSelectAll = (evt: KeyboardEvent) => {
+
+    const onSelected = () => setTimeout(() => {
+      if (currentTarget?.selector.length > 0) {
+        selection.clear();
+
+        store.addAnnotation({
+          id: currentTarget.annotation,
+          bodies: [],
+          target: currentTarget
+        });
+
+        selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));
+      }
+      
+      document.removeEventListener('selectionchange', onSelected);
+
+      // Sigh... this needs a delay to work. But doesn't seem reliable.
+    }, 100);
+
+    // Listen to the change event that follows
+    document.addEventListener('selectionchange', onSelected);
+    
+    // Start selection!
     onSelectStart(evt);
-
-    // Proper lifecycle management: clear selection first...
-    selection.clear();
-
-    setTimeout(() => {
-      // ...then add annotation to store...
-      store.addAnnotation({
-        id: currentTarget.annotation,
-        bodies: [],
-        target: currentTarget
-      });
-
-      selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));
-
-      // Sigh.. not sure there's a reliable timeout. Alternative would be
-      // to listen to the selectionchange event once?
-    }, 250);
   }
 
   hotkeys(SELECTION_KEYS.join(','), { element: container, keydown: true, keyup: false }, evt => {

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -10,6 +10,7 @@ import {
   debounce,
   splitAnnotatableRanges,
   rangeToSelector,
+  isMac,
   isWhitespaceOrEmpty,
   trimRangeToContainer,
   NOT_ANNOTATABLE_SELECTOR
@@ -19,11 +20,11 @@ const CLICK_TIMEOUT = 300;
 
 const ARROW_KEYS = ['up', 'down', 'left', 'right'];
 
-const SELECT_ALL = ['ctrl+a', '⌘+a'];
+const SELECT_ALL = isMac ? '⌘+a' :  'ctrl+a';
 
 const SELECTION_KEYS = [
   ...ARROW_KEYS.map(key => `shift+${key}`),
-  ...SELECT_ALL
+  SELECT_ALL
 ];
 
 export const SelectionHandler = (
@@ -271,7 +272,7 @@ export const SelectionHandler = (
       lastDownEvent = cloneKeyboardEvent(evt);
   });
 
-  hotkeys(SELECT_ALL.join(','), { keydown: true, keyup: false}, evt => {
+  hotkeys(SELECT_ALL, { keydown: true, keyup: false}, evt => {
     lastDownEvent = cloneKeyboardEvent(evt);
     onSelectAll(evt);
   });

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -50,8 +50,6 @@ export const SelectionHandler = (
 
   let lastDownEvent: Selection['event'] | undefined;
 
-  let isContextMenuOpen = false;
-
   const onSelectStart = (evt: Event) => {
     if (isLeftClick === false)
       return;
@@ -154,8 +152,6 @@ export const SelectionHandler = (
    * to the initial pointerdown event and remember the button
    */
   const onPointerDown = (evt: PointerEvent) => {
-    if (isContextMenuOpen) return;
-
     const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
     if (!annotatable) return;
 
@@ -182,8 +178,6 @@ export const SelectionHandler = (
   }
 
   const onPointerUp = (evt: PointerEvent) => {
-    if (isContextMenuOpen) return;
-
     const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
     if (!annotatable || !isLeftClick) return;
 
@@ -233,16 +227,15 @@ export const SelectionHandler = (
   }
 
   const onContextMenu = (evt: PointerEvent) => {
-    isContextMenuOpen = true;
-
     const sel = document.getSelection();
 
     if (sel?.isCollapsed) return;
 
     // When selecting the initial word, Chrome Android fires `contextmenu` 
     // before selectionChanged.
-    if (!currentTarget || currentTarget.selector.length === 0)
+    if (!currentTarget || currentTarget.selector.length === 0) {
       onSelectionChange(evt);
+    }
     
     upsertCurrentTarget();
 

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -271,12 +271,19 @@ export const SelectionHandler = (
     // Proper lifecycle management: clear selection first...
     selection.clear();
 
-    // ...then add annotation to store...
-    store.addAnnotation({
-      id: currentTarget.annotation,
-      bodies: [],
-      target: currentTarget
-    });
+    setTimeout(() => {
+      // ...then add annotation to store...
+      store.addAnnotation({
+        id: currentTarget.annotation,
+        bodies: [],
+        target: currentTarget
+      });
+
+      selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));
+
+      // Sigh.. not sure there's a reliable timeout. Alternative would be
+      // to listen to the selectionchange event once?
+    }, 250);
   }
 
   hotkeys(SELECTION_KEYS.join(','), { element: container, keydown: true, keyup: false }, evt => {

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -228,15 +228,16 @@ export const SelectionHandler = (
 
   const onContextMenu = (evt: PointerEvent) => {
     const sel = document.getSelection();
-    if (sel?.isCollapsed) return;
 
-    // selection.clear();
+    if (sel?.isCollapsed) return;
 
     const exists = store.getAnnotation(currentTarget.annotation);
     if (exists) {
       // ...then add annotation to store...
       store.updateTarget(currentTarget);
     } else {
+      selection.clear();
+      
       // ...then add annotation to store...
       store.addAnnotation({
         id: currentTarget.annotation,

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -117,6 +117,8 @@ export const SelectionHandler = (
         store.deleteAnnotation(currentTarget.annotation);
       }
 
+      currentTarget = undefined;
+
       return;
     }
 
@@ -144,21 +146,7 @@ export const SelectionHandler = (
     // being edited. But it will typcially be the case on mobile!
     if (store.getAnnotation(currentTarget.annotation)) {
       store.updateTarget(currentTarget, Origin.LOCAL);
-    } /* else {
-      // Proper lifecycle management: clear selection first...
-      selection.clear();
-
-      // ...then add annotation to store...
-      store.addAnnotation({
-        id: currentTarget.annotation,
-        bodies: [],
-        target: currentTarget
-      });
-
-      // ...then make the new annotation the current selection
-      selection.userSelect(currentTarget.annotation, lastDownEvent);
     }
-      */
   });
 
   /**

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -236,6 +236,23 @@ export const SelectionHandler = (
     });
   }
 
+  const onKeyup = (evt: KeyboardEvent) => {
+    if (evt.key === 'Shift' && currentTarget) {
+      // Proper lifecycle management: clear selection first...
+      selection.clear();
+
+      // ...then add annotation to store...
+      store.addAnnotation({
+        id: currentTarget.annotation,
+        bodies: [],
+        target: currentTarget
+      });
+
+      // ...then make the new annotation the current selection
+      selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));
+    }
+  }
+
   hotkeys(SELECTION_KEYS.join(','), { element: container, keydown: true, keyup: false }, (evt) => {
     if (!evt.repeat)
       lastDownEvent = cloneKeyboardEvent(evt);
@@ -267,6 +284,7 @@ export const SelectionHandler = (
   document.addEventListener('pointerup', onPointerUp);
 
   if (annotatingEnabled) {
+    container.addEventListener('keyup', onKeyup);
     container.addEventListener('selectstart', onSelectStart);
     document.addEventListener('selectionchange', onSelectionChange);
   }
@@ -275,6 +293,7 @@ export const SelectionHandler = (
     container.removeEventListener('pointerdown', onPointerDown);
     document.removeEventListener('pointerup', onPointerUp);
 
+    container.removeEventListener('keyup', onKeyup);
     container.removeEventListener('selectstart', onSelectStart);
     document.removeEventListener('selectionchange', onSelectionChange);
 

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -297,6 +297,7 @@ export const SelectionHandler = (
 
   container.addEventListener('pointerdown', onPointerDown);
   document.addEventListener('pointerup', onPointerUp);
+  document.addEventListener('contextmenu', onPointerUp);
 
   if (annotatingEnabled) {
     container.addEventListener('keyup', onKeyup);
@@ -307,6 +308,7 @@ export const SelectionHandler = (
   const destroy = () => {
     container.removeEventListener('pointerdown', onPointerDown);
     document.removeEventListener('pointerup', onPointerUp);
+    document.removeEventListener('contextmenu', onPointerUp);
 
     container.removeEventListener('keyup', onKeyup);
     container.removeEventListener('selectstart', onSelectStart);

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -50,6 +50,8 @@ export const SelectionHandler = (
 
   let lastDownEvent: Selection['event'] | undefined;
 
+  let isContextMenuOpen = false;
+
   const onSelectStart = (evt: Event) => {
     if (isLeftClick === false)
       return;
@@ -152,6 +154,8 @@ export const SelectionHandler = (
    * to the initial pointerdown event and remember the button
    */
   const onPointerDown = (evt: PointerEvent) => {
+    if (isContextMenuOpen) return;
+
     const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
     if (!annotatable) return;
 
@@ -178,6 +182,8 @@ export const SelectionHandler = (
   }
 
   const onPointerUp = (evt: PointerEvent) => {
+    if (isContextMenuOpen) return;
+
     const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
     if (!annotatable || !isLeftClick) return;
 
@@ -227,6 +233,8 @@ export const SelectionHandler = (
   }
 
   const onContextMenu = (evt: PointerEvent) => {
+    isContextMenuOpen = true;
+
     const sel = document.getSelection();
 
     if (sel?.isCollapsed) return;

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -95,10 +95,8 @@ export const SelectionHandler = (
 
       } else if (sel.isCollapsed && timeDifference < CLICK_TIMEOUT) {
 
-        /*
-         Firefox doesn't fire the 'selectstart' when user clicks
-         over the text, which collapses the selection
-        */
+        // Firefox doesn't fire the 'selectstart' when user clicks
+        // over the text, which collapses the selection
         onSelectStart(lastDownEvent || evt);
 
       }
@@ -142,9 +140,11 @@ export const SelectionHandler = (
       updated: new Date()
     };
 
+    // On destkop, the annotation won't usually exist while the selection is
+    // being edited. But it will typcially be the case on mobile!
     if (store.getAnnotation(currentTarget.annotation)) {
       store.updateTarget(currentTarget, Origin.LOCAL);
-    } else {
+    } /* else {
       // Proper lifecycle management: clear selection first...
       selection.clear();
 
@@ -158,6 +158,7 @@ export const SelectionHandler = (
       // ...then make the new annotation the current selection
       selection.userSelect(currentTarget.annotation, lastDownEvent);
     }
+      */
   });
 
   /**
@@ -218,8 +219,19 @@ export const SelectionHandler = (
       if (sel?.isCollapsed && timeDifference < CLICK_TIMEOUT) {
         currentTarget = undefined;
         clickSelect();
-      } else if (currentTarget && store.getAnnotation(currentTarget.annotation)) {
-        selection.userSelect(currentTarget.annotation, evt);
+      } else if (currentTarget) {
+        // Proper lifecycle management: clear selection first...
+        selection.clear();
+
+        // ...then add annotation to store...
+        store.addAnnotation({
+          id: currentTarget.annotation,
+          bodies: [],
+          target: currentTarget
+        });
+
+        // ...then make the new annotation the current selection
+        selection.userSelect(currentTarget.annotation, clonePointerEvent(evt));
       }
     });
   }

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -230,12 +230,18 @@ export const SelectionHandler = (
         // Proper lifecycle management: clear selection first...
         selection.clear();
 
-        // ...then add annotation to store...
-        store.addAnnotation({
-          id: currentTarget.annotation,
-          bodies: [],
-          target: currentTarget
-        });
+        const exists = store.getAnnotation(currentTarget.annotation);
+        if (exists) {
+          // ...then add annotation to store...
+          store.updateTarget(currentTarget);
+        } else {
+          // ...then add annotation to store...
+          store.addAnnotation({
+            id: currentTarget.annotation,
+            bodies: [],
+            target: currentTarget
+          });
+        }
 
         // ...then make the new annotation the current selection
         selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -50,7 +50,11 @@ export const SelectionHandler = (
 
   let lastDownEvent: Selection['event'] | undefined;
 
+  let isContextMenuOpen = false;
+
   const onSelectStart = (evt: Event) => {
+    isContextMenuOpen = false;
+    
     if (isLeftClick === false)
       return;
 
@@ -152,6 +156,8 @@ export const SelectionHandler = (
    * to the initial pointerdown event and remember the button
    */
   const onPointerDown = (evt: PointerEvent) => {
+    if (isContextMenuOpen) return;
+
     const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
     if (!annotatable) return;
 
@@ -178,6 +184,8 @@ export const SelectionHandler = (
   }
 
   const onPointerUp = (evt: PointerEvent) => {
+    if (isContextMenuOpen) return;
+
     const annotatable = !(evt.target as Node).parentElement?.closest(NOT_ANNOTATABLE_SELECTOR);
     if (!annotatable || !isLeftClick) return;
 
@@ -227,6 +235,8 @@ export const SelectionHandler = (
   }
 
   const onContextMenu = (evt: PointerEvent) => {
+    isContextMenuOpen = true;
+
     const sel = document.getSelection();
 
     if (sel?.isCollapsed) return;

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -201,8 +201,9 @@ export const SelectionHandler = (
       if (hovered) {
         const { selected } = selection;
 
-        if (selected.length !== 1 || selected[0].id !== hovered.id)
+        if (selected.length !== 1 || selected[0].id !== hovered.id) {
           selection.userSelect(hovered.id, evt);
+        }
       } else if (!selection.isEmpty()) {
         selection.clear();
       } 
@@ -226,7 +227,7 @@ export const SelectionHandler = (
       if (sel?.isCollapsed && timeDifference < CLICK_TIMEOUT) {
         currentTarget = undefined;
         clickSelect();
-      } else if (currentTarget) {
+      } else if (currentTarget && currentTarget.selector.length > 0) {
         selection.clear();
         upsertCurrentTarget();
         selection.userSelect(currentTarget.annotation, clonePointerEvent(evt));

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -117,8 +117,6 @@ export const SelectionHandler = (
         store.deleteAnnotation(currentTarget.annotation);
       }
 
-      currentTarget = undefined;
-
       return;
     }
 
@@ -201,7 +199,7 @@ export const SelectionHandler = (
      * @see https://github.com/recogito/text-annotator-js/issues/136
      */
     setTimeout(() => {
-      const sel = document.getSelection()
+      const sel = document.getSelection();
 
       // Just a click, not a selection
       if (sel?.isCollapsed && timeDifference < CLICK_TIMEOUT) {
@@ -226,18 +224,22 @@ export const SelectionHandler = (
 
   const onKeyup = (evt: KeyboardEvent) => {
     if (evt.key === 'Shift' && currentTarget) {
-      // Proper lifecycle management: clear selection first...
-      selection.clear();
+      const sel = document.getSelection();
 
-      // ...then add annotation to store...
-      store.addAnnotation({
-        id: currentTarget.annotation,
-        bodies: [],
-        target: currentTarget
-      });
+      if (!sel.isCollapsed) {
+        // Proper lifecycle management: clear selection first...
+        selection.clear();
 
-      // ...then make the new annotation the current selection
-      selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));
+        // ...then add annotation to store...
+        store.addAnnotation({
+          id: currentTarget.annotation,
+          bodies: [],
+          target: currentTarget
+        });
+
+        // ...then make the new annotation the current selection
+        selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));
+      }
     }
   }
 

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -143,8 +143,10 @@ export const SelectionHandler = (
       updated: new Date()
     };
 
-    // On destkop, the annotation won't usually exist while the selection is
-    // being edited. But it will typcially be the case on mobile!
+    /**
+     * During mouse selection on the desktop, annotation won't usually exist while the selection is being edited.
+     * But it will be typical during keyboard or mobile handlebars selection!
+     */
     if (store.getAnnotation(currentTarget.annotation)) {
       store.updateTarget(currentTarget, Origin.LOCAL);
     }

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -206,7 +206,7 @@ export const SelectionHandler = (
         }
       } else if (!selection.isEmpty()) {
         selection.clear();
-      } 
+      }
     };
 
     const timeDifference = evt.timeStamp - lastDownEvent.timeStamp;

--- a/packages/text-annotator/src/utils/device.ts
+++ b/packages/text-annotator/src/utils/device.ts
@@ -1,0 +1,2 @@
+// @ts-ignore
+export const isMac = /mac/i.test(navigator.userAgentData ? navigator.userAgentData.platform : navigator.platform);

--- a/packages/text-annotator/src/utils/index.ts
+++ b/packages/text-annotator/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './cancelSingleClickEvents';
+export * from './device';
 export * from './programmaticallyFocusable';
 export * from './debounce';
 export * from './getAnnotatableFragment';


### PR DESCRIPTION
## In this PR

This PR revises the selection behavior fundamentally. Instead of creating an annotation immediately, the SelectionHandler now waits until the (native browser text-)selection is 'complete'. Because there is not actually a 'complete' event, there are different approaches, depending on platform and interaction mode:

- For __mouse interaction__ a complete selection is determined by a `pointerup` event.
- For __keyboard interaction__ a complete selection is determined by the `keyup` event of the Shift key. (Note that selection remains editable - unless popup intervenes.)
- `Ctrl` + `A` (or `Cmd` + `A`) is handled separately, as a single operation.
- __iOS/iPad__: complete selection is determined by `pointerup` or `contextmenu` event.
- __Android__: complete selection is determined by the `contextmenu` event. 

__Note:__ in all cases, the selection remains editable after "completion", either by using Shift+Arrow keys (desktop) or by dragging the handlebars (on mobile/touch). 

### React Popup

I also modified the React `TextAnnotatorPopup` with the following behaviors: 

- On mobile, the popup is oriented __below__ the annotation (instead of the default above), since it would otherwise be obstructed by the default system context menu on iOS and Android.
- On mobile, the popup does not receive initial focus. The user must explicitly tap into it. This way, the selection handlebars remain activated, and it is still possible to alter the selection after the popup has opened.

__Warning:__ mobile mode is detected through `navigator.userAgent`. It appears that Firefox currently __does not include sufficient information to determine whether it is running on iOS__. Therefore, FF/iOS currently behaves like on the desktop, which also means it will lose the selection handlebars as soon as the `<TextAnnotatorPopup>` opens.