### PR TITLE
Added missing previous selection discard upon the new selection change

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -209,7 +209,7 @@ export const SelectionHandler = (
         if (selected.length !== 1 || selected[0].id !== hovered.id) {
           selection.userSelect(hovered.id, evt);
         }
-      } else if (!selection.isEmpty()) {
+      } else {
         selection.clear();
       }
     };

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -149,6 +149,9 @@ export const SelectionHandler = (
      */
     if (store.getAnnotation(currentTarget.annotation)) {
       store.updateTarget(currentTarget, Origin.LOCAL);
+    } else {
+      // Proper lifecycle management: clear the previous selection first...
+      selection.clear();
     }
   });
 


### PR DESCRIPTION
## Issue
Initially reported - https://github.com/recogito/text-annotator-js/pull/151#discussion_r1795661665

> We need to restore the selection.clear() call if there's nothing to update. Because now the previous, "discarded selection" unexpectedly stays up until you create a brand-new one.
>
> https://github.com/user-attachments/assets/cb0d6edc-5a48-400b-90f8-a61c41251200
>
>*in my testing env, the annotations that don't have either a highlight or a note assigned get automatically garbage collected when they get unselected

Can be reproduced in the playground: 

https://github.com/user-attachments/assets/81bf9fc7-380d-4438-a81e-d0d6365b251d

