### PR TITLE
Fixed overeager popup closure on touch devices

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -111,12 +111,6 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
     };
   }, [update]);
 
-  // Prevent text-annotator from handling the irrelevant events triggered from the popup
-  const getStopEventsPropagationProps = useCallback(
-    () => ({ onPointerUp: (event: PointerEvent<HTMLDivElement>) => event.stopPropagation() }),
-    []
-  );
-
   // Don't shift focus to the floating element if selected via keyboard or on mobile.
   const initialFocus = useMemo(() => {
     return (event?.type === 'keyup' || event?.type === 'contextmenu' || isMobile()) ? -1 : 0;
@@ -136,8 +130,7 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
           className="a9s-popup r6o-popup annotation-popup r6o-text-popup not-annotatable"
           ref={refs.setFloating}
           style={floatingStyles}
-          {...getFloatingProps()}
-          {...getStopEventsPropagationProps()}>
+          {...getFloatingProps(getStopEventsPropagationProps())}>
           {props.popup({
             annotation: selected[0].annotation,
             editable: selected[0].editable,
@@ -153,3 +146,14 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
   ) : null;
 
 }
+
+/**
+ * Prevent text-annotator from handling the irrelevant events
+ * triggered from the popup/toolbar/dialog
+ */
+export const getStopEventsPropagationProps = <T extends HTMLElement = HTMLElement>() => ({
+  onPointerUp: (event: PointerEvent<T>) => event.stopPropagation(),
+  onPointerDown: (event: PointerEvent<T>) => event.stopPropagation(),
+  onMouseDown: (event: MouseEvent<T>) => event.stopPropagation(),
+  onMouseUp: (event: MouseEvent<T>) => event.stopPropagation()
+});

--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -64,10 +64,8 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
     whileElementsMounted: autoUpdate
   });
 
-  const dismiss = useDismiss(context);
-
   const role = useRole(context, { role: 'dialog' });
-
+  const dismiss = useDismiss(context, { outsidePressEvent: 'mousedown' });
   const { getFloatingProps } = useInteractions([dismiss, role]);
 
   useEffect(() => {


### PR DESCRIPTION
## Issue
When a user scrolls upon the popup opening - the latter gets closed instead of being scrolled along! The issue is the [`outsidePressEvent`](https://floating-ui.com/docs/useDismiss#outsidepressevent) that's `pointerdown` by default. Therefore, it would immediately dismiss the popup when a user touches their screen. Instead, we can use a bit more touch-friendly `mousedown`: 
```ts
useDismiss(context, {
  // Eager on both mouse + touch input.
  outsidePressEvent: 'pointerdown',
  // Eager on mouse input; lazy on touch input.
  outsidePressEvent: 'mousedown',
  // Lazy on both mouse + touch input.
  outsidePressEvent: 'click',
});
```
So when a user touches a screen and drags the popup won't be dismissed, only when the user touches and releases almost immediately.