### PR TITLE
Simplified popup opening check with `isRevived`

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -1,6 +1,6 @@
 import { PointerEvent, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAnnotator, useSelection } from '@annotorious/react';
-import type { TextAnnotation, TextAnnotator } from '@recogito/text-annotator';
+import { isRevived, TextAnnotation, TextAnnotator } from '@recogito/text-annotator';
 import { isMobile } from './isMobile';
 import {
   autoUpdate,
@@ -71,15 +71,10 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
   const { getFloatingProps } = useInteractions([dismiss, role]);
 
   useEffect(() => {
-    setOpen(
-      // Selected annotation exists and has a selector?
-      annotation?.target.selector && 
-      // Selector not empty? (Annotations from plugins, general defensive programming)
-      annotation.target.selector.length > 0 && 
-      // Range not collapsed? (E.g. lazy loading PDFs. Note that this will have to 
-      // change if we switch from ranges to pre-computed bounds!)
-      !annotation.target.selector[0].range.collapsed
-    );
+    const annotationSelector = annotation?.target.selector;
+    if (!annotationSelector) return;
+
+    setOpen(isRevived(annotationSelector));
   }, [annotation]);
 
   useEffect(() => {


### PR DESCRIPTION
## Issue
The popup opened state check is almost a duplicate of the existing `isRevived` utility. It already does the check for the ranges presence and whether they are not collapsed. 