### PR TITLE
⚠️ Fixed checking `null` selection `anchorNode` for being `not-annotatable` ⚠️

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -80,7 +80,7 @@ export const SelectionHandler = (
     // This is to handle cases where the selection is "hijacked" by another element
     // in a not-annotatable area. A rare case in theory. But rich text editors
     // will like Quill do it...
-    if (isNotAnnotatable(sel.anchorNode)) {
+    if (!sel?.isCollapsed && isNotAnnotatable(sel.anchorNode)) {
       currentTarget = undefined;
       return;
     }


### PR DESCRIPTION
## Issue
On `iOS` when the user clicks a button it emits the `selectionchange` event! While listening to the `selectionchange` - we check whether its `achorNode` is even annotatable. https://github.com/recogito/text-annotator-js/blob/c5ffd362e977ff788991609cef40b344e34ea7f6/packages/text-annotator/src/SelectionHandler.ts#L77-L86

However, I discovered that sometimes when a button is clicked - it produces a collapsed selection where the `anchorNode` is `null`:
![image](https://github.com/user-attachments/assets/e83c18da-3d79-4d05-8e9c-3bcdeb7042b5)
Then, null` gets passed to the `isNotAnnotatable` and _expectedly fails_:
![image](https://github.com/user-attachments/assets/0c241c5b-e874-46e2-8a1b-bd2e928c8b12)

## Changes Made
Added the collapsed state check before running the `isNotAnnotatable` on the selection range's `anchorNode`