### PR TITLE
Fixed false-positive `open` setting

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotatorPopup/TextAnnotatorPopup.tsx
@@ -72,7 +72,7 @@ export const TextAnnotatorPopup = (props: TextAnnotationPopupProps) => {
 
   useEffect(() => {
     const annotationSelector = annotation?.target.selector;
-    if (!annotationSelector) return;
+    if (!annotationSelector?.length) return;
 
     setOpen(isRevived(annotationSelector));
   }, [annotation]);


### PR DESCRIPTION
## Issue
This PR is a follow-up on https://github.com/recogito/text-annotator-js/pull/161 where I accidentally introduced a false-positive setting for the `open` state of the popup. In the current logic, despite the `annotation?.target.selector` being an empty array - it'll still pass the `isRevived` check due to the `.every` nature!
https://github.com/recogito/text-annotator-js/blob/69be7ea1b6a8be3dcd4e02e7803179c6a37a4f6d/packages/text-annotator/src/utils/isRevived.ts#L3-L4
![image](https://github.com/user-attachments/assets/5478891d-74f9-4fde-a261-b4d92045625f)

Therefore:

![image](https://github.com/user-attachments/assets/74d8359d-2008-4382-8b09-f398e77abfd7)

