### PR TITLE
Removed `pointerup`/`pointerdown` events blocking by the `contextmenu` presence

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -50,11 +50,7 @@ export const SelectionHandler = (
 
   let lastDownEvent: Selection['event'] | undefined;
 
-  let isContextMenuOpen = false;
-
   const onSelectStart = (evt: Event) => {
-    isContextMenuOpen = false;
-    
     if (isLeftClick === false)
       return;
 
@@ -161,8 +157,6 @@ export const SelectionHandler = (
    * to the initial pointerdown event and remember the button
    */
   const onPointerDown = (evt: PointerEvent) => {
-    if (isContextMenuOpen) return;
-
     if (isNotAnnotatable(evt.target as Node)) return;
 
     /**
@@ -188,8 +182,6 @@ export const SelectionHandler = (
   }
 
   const onPointerUp = (evt: PointerEvent) => {
-    if (isContextMenuOpen) return;
-
     if (isNotAnnotatable(evt.target as Node) || !isLeftClick) return;
 
     // Logic for selecting an existing annotation
@@ -239,8 +231,6 @@ export const SelectionHandler = (
   }
 
   const onContextMenu = (evt: PointerEvent) => {
-    isContextMenuOpen = true;
-
     const sel = document.getSelection();
 
     if (sel?.isCollapsed) return;
@@ -282,7 +272,7 @@ export const SelectionHandler = (
 
         selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));
       }
-      
+
       document.removeEventListener('selectionchange', onSelected);
 
       // Sigh... this needs a delay to work. But doesn't seem reliable.
@@ -290,7 +280,7 @@ export const SelectionHandler = (
 
     // Listen to the change event that follows
     document.addEventListener('selectionchange', onSelected);
-    
+
     // Start selection!
     onSelectStart(evt);
   }


### PR DESCRIPTION
## Issue
Initially discovered here - https://github.com/recogito/text-annotator-js/pull/151#discussion_r1821084171
> With the `isContextMenuOpen` check in place, it takes a user to tap twice on the screen to dismiss the selected annotation. The first tap is needed to dismiss the context menu and the second one is to dismiss the annotation itself.
That makes the annotation selection look like it's lagging behind 🤔 
> 
> https://github.com/user-attachments/assets/c096cb58-194d-430c-a513-c6e4ec735ce3

---

##### However, the issue isn't present on `iOS`, because the `contextmenu` event isn't dispatched there:
<img width="590" src="https://github.com/user-attachments/assets/0fed5859-f50f-450a-8db4-d43fb3ef8ef6" />
