### PR TITLE
Bumped `uuid` to `^11.0.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1935,13 +1935,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.2.tgz",
@@ -4578,12 +4571,11 @@
         "dequal": "^2.0.3",
         "hotkeys-js": "^3.13.7",
         "rbush": "^4.0.1",
-        "uuid": "^10.0.0"
+        "uuid": "^11.0.2"
       },
       "devDependencies": {
         "@types/jsdom": "^21.1.7",
         "@types/rbush": "^4.0.0",
-        "@types/uuid": "^10.0.0",
         "jsdom": "^25.0.1",
         "svelte": "^4.2.19",
         "typescript": "5.6.2",
@@ -4623,6 +4615,19 @@
         "openseadragon": {
           "optional": true
         }
+      }
+    },
+    "packages/text-annotator/node_modules/uuid": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+      "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     }
   }

--- a/packages/text-annotator/package.json
+++ b/packages/text-annotator/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@types/jsdom": "^21.1.7",
     "@types/rbush": "^4.0.0",
-    "@types/uuid": "^10.0.0",
     "jsdom": "^25.0.1",
     "svelte": "^4.2.19",
     "typescript": "5.6.2",
@@ -42,6 +41,6 @@
     "dequal": "^2.0.3",
     "hotkeys-js": "^3.13.7",
     "rbush": "^4.0.1",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.2"
   }
 }


### PR DESCRIPTION
Recently UUID library received a major release that brought in bugfixes, performance improvements, and the native TS support 🙌🏻 
See - https://github.com/uuidjs/uuid/releases/tag/v11.0.0