### PR TITLE
Added W3C `scope` property support parsing/serialization

### DIFF
--- a/packages/text-annotator/src/model/core/TextAnnotation.ts
+++ b/packages/text-annotator/src/model/core/TextAnnotation.ts
@@ -24,6 +24,8 @@ export interface TextSelector {
 
   range: Range;
 
-  offsetReference?: HTMLElement
+  offsetReference?: HTMLElement;
+
+  scope?: string;
 
 }

--- a/packages/text-annotator/src/model/w3c/W3CTextAnnotation.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextAnnotation.ts
@@ -14,6 +14,8 @@ export interface W3CTextAnnotationTarget extends W3CAnnotationTarget {
 
   styleClass?: string;
 
+  scope?: string;
+
 }
 
 /**

--- a/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
@@ -64,7 +64,11 @@ const parseW3CTextTargets = (annotation: W3CTextAnnotation) => {
     }, {});
 
     if (isTextSelector(selector)) {
-      parsed.selector.push({ id: w3cTarget.id, ...selector });
+      parsed.selector.push({
+        ...selector,
+        id: w3cTarget.id,
+        scope: w3cTarget.scope
+      });
     } else {
       const missingTypes = [
         !selector.start ? 'TextPositionSelector' : undefined,
@@ -123,7 +127,7 @@ export const serializeW3CTextAnnotation = (
   } = target;
 
   const w3cTargets = selector.map((s) => {
-    const { quote, start, end, range } = s;
+    const { id, scope, quote, start, end, range } = s;
 
     const { prefix, suffix } = getQuoteContext(range, container);
 
@@ -140,7 +144,8 @@ export const serializeW3CTextAnnotation = (
 
     return {
       ...targetRest,
-      id: s.id,
+      id,
+      scope,
       source,
       selector: w3cSelectors
     };


### PR DESCRIPTION
## Issue
We have a need to associate a certain W3C `target` with a certain covered "resource"/"element" on a page. To not create custom properties for the W3C model, like `element_family_id`, we decided to go with the existing [`scope` property](https://www.w3.org/TR/annotation-model/#scope-of-a-resource).
> It is sometimes important for an Annotation to capture the context in which it was made in terms of the resources that the annotator was viewing or using at the time

However, as for the `styleClass` (https://github.com/recogito/text-annotator-js/pull/72), it's not enough to declare the type for W3C/internal model locally. It needs to be explicitly processed by the `W3CTextFormatAdapter`.