### PR TITLE
#179 Removed excessive selection cleanup

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -219,7 +219,6 @@ export const SelectionHandler = (
         currentTarget = undefined;
         clickSelect();
       } else if (currentTarget && currentTarget.selector.length > 0) {
-        selection.clear();
         upsertCurrentTarget();
         selection.userSelect(currentTarget.annotation, clonePointerEvent(evt));
       }
@@ -247,7 +246,6 @@ export const SelectionHandler = (
       const sel = document.getSelection();
 
       if (!sel.isCollapsed) {
-        selection.clear();
         upsertCurrentTarget();
         selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));
       }


### PR DESCRIPTION
## Issue
See - https://github.com/recogito/text-annotator-js/issues/179

## Changes Made
I removed the excessive `selection.clean()` calls that can cause losing the same selected annotation reference. Previously upon releasing the `Shift` or a finger, the selection was cleared out and immediately updated. That cleanup would make the consumer think that a brand-new annotation was selected while the user just kept selecting the text after a pause.
Additionally, that cleanup is processed inconsistency in React 18 vs React <18 consumers.

Now, the selection is cleared only on:
- `selectionchange` event is emitted but there's no `currentTarget` present (already in place)
- On "Select All" handling
- On an arbitrary arrow press
- Click beyond the annotation range