### PR TITLE
Generalized `W3CTextFormatAdapter`

### DIFF
--- a/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
@@ -10,17 +10,17 @@ import type { TextAnnotation, TextAnnotationTarget, TextSelector } from '../core
 import type { W3CTextAnnotation, W3CTextAnnotationTarget, W3CTextSelector } from '../w3c';
 import { getQuoteContext } from '../../utils';
 
-export type W3CTextFormatAdapter = FormatAdapter<TextAnnotation, W3CTextAnnotation>;
+export type W3CTextFormatAdapter<I extends TextAnnotation = TextAnnotation, E extends W3CTextAnnotation = W3CTextAnnotation> = FormatAdapter<I, E>;
 
 /**
  * @param source - the IRI of the annotated content
  * @param container - the HTML container of the annotated content,
  *                    Required to locate the content's `range` within the DOM
  */
-export const W3CTextFormat = (
+export const W3CTextFormat = <E extends W3CTextAnnotation = W3CTextAnnotation>(
   source: string,
   container: HTMLElement
-): W3CTextFormatAdapter => ({
+): W3CTextFormatAdapter<TextAnnotation, E> => ({
   parse: (serialized) => parseW3CTextAnnotation(serialized),
   serialize: (annotation) => serializeW3CTextAnnotation(annotation, source, container)
 });
@@ -119,11 +119,11 @@ export const parseW3CTextAnnotation = (
 
 };
 
-export const serializeW3CTextAnnotation = (
+export const serializeW3CTextAnnotation = <E extends W3CTextAnnotation = W3CTextAnnotation>(
   annotation: TextAnnotation,
   source: string,
   container: HTMLElement
-): W3CTextAnnotation => {
+): E => {
   const { bodies, target, ...rest } = annotation;
 
   const {
@@ -171,6 +171,6 @@ export const serializeW3CTextAnnotation = (
     created: created?.toISOString(),
     modified: updated?.toISOString(),
     target: w3cTargets
-  };
+  } as E;
 
 };


### PR DESCRIPTION
## Changes Made
I made the `W3CTextFormatAdapter` generalized for the package consumers.

For that, I followed the `TextAnnotator` and `createTextAnnotator` definition example:
https://github.com/recogito/text-annotator-js/blob/ff7100718a0ee9b0366942df0c65adba24646f42/packages/text-annotator/src/TextAnnotator.ts#L17
https://github.com/recogito/text-annotator-js/blob/ff7100718a0ee9b0366942df0c65adba24646f42/packages/text-annotator/src/TextAnnotator.ts#L30-L33

That will help to utilize custom W3C definitions on the consumer's side w/o triggering the following errors:
![image](https://github.com/user-attachments/assets/b9eaf20a-16f8-433c-912c-e82c82be7e6e)
<img width="355" alt="error details" src="https://github.com/user-attachments/assets/288643ba-1612-4009-a9b4-dc975df29280">
