### PR TITLE
Broaden the internal type generic usage

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -12,7 +12,7 @@ export interface TextAnnotatorProps<E extends unknown> extends Omit<TextAnnotato
 
   adapter?: FormatAdapter<TextAnnotation, E> | ((container: HTMLElement) => FormatAdapter<TextAnnotation, E>) | null;
 
-  filter?: Filter;
+  filter?: Filter<TextAnnotation>;
 
   style?: HighlightStyleExpression;
 

--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -6,13 +6,13 @@ import { createTextAnnotator } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/dist/text-annotator.css';
 
-export interface TextAnnotatorProps<E extends unknown> extends Omit<TextAnnotatorOptions<TextAnnotation, E>, 'adapter'> {
+export interface TextAnnotatorProps<I extends TextAnnotation = TextAnnotation, E extends unknown = TextAnnotation> extends Omit<TextAnnotatorOptions<I, E>, 'adapter'> {
 
   children?: ReactNode | JSX.Element;
 
-  adapter?: FormatAdapter<TextAnnotation, E> | ((container: HTMLElement) => FormatAdapter<TextAnnotation, E>) | null;
+  adapter?: FormatAdapter<I, E> | ((container: HTMLElement) => FormatAdapter<I, E>) | null;
 
-  filter?: Filter<TextAnnotation>;
+  filter?: Filter<I>;
 
   style?: HighlightStyleExpression;
 
@@ -20,7 +20,9 @@ export interface TextAnnotatorProps<E extends unknown> extends Omit<TextAnnotato
 
 }
 
-export const TextAnnotator = <E extends unknown>(props: TextAnnotatorProps<E>) => {
+export const TextAnnotator = <I extends TextAnnotation = TextAnnotation, E extends unknown = TextAnnotation>(
+  props: TextAnnotatorProps<I, E>
+) => {
 
   const el = useRef<HTMLDivElement>(null);
 

--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -27,23 +27,23 @@ export interface TextAnnotator<I extends TextAnnotation = TextAnnotation, E exte
 
 }
 
-export const createTextAnnotator = <E extends unknown = TextAnnotation>(
+export const createTextAnnotator = <I extends TextAnnotation = TextAnnotation, E extends unknown = TextAnnotation>(
   container: HTMLElement,
-  options: TextAnnotatorOptions<TextAnnotation, E> = {}
-): TextAnnotator<TextAnnotation, E> => {
+  options: TextAnnotatorOptions<I, E> = {}
+): TextAnnotator<I, E> => {
   // Prevent mobile browsers from triggering word selection on single click.
   cancelSingleClickEvents(container);
 
   // Make sure that the container is focusable and can receive both pointer and keyboard events
   programmaticallyFocusable(container);
 
-  const opts = fillDefaults<TextAnnotation, E>(options, {
+  const opts = fillDefaults<I, E>(options, {
     annotatingEnabled: true,
     user: createAnonymousGuest()
   });
 
-  const state: TextAnnotatorState<TextAnnotation, E> = 
-    createTextAnnotatorState<TextAnnotation, E>(container, opts.userSelectAction);
+  const state: TextAnnotatorState<I, E> =
+    createTextAnnotatorState<I, E>(container, opts.userSelectAction);
 
   const { selection, viewport } = state;
 
@@ -51,7 +51,7 @@ export const createTextAnnotator = <E extends unknown = TextAnnotation>(
 
   const undoStack = createUndoStack(store);
 
-  const lifecycle = createLifecycleObserver<TextAnnotation, E>(state, undoStack, opts.adapter);
+  const lifecycle = createLifecycleObserver<I, E>(state, undoStack, opts.adapter);
 
   let currentUser: User = opts.user;
 

--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -84,11 +84,11 @@ export const createTextAnnotator = <I extends TextAnnotation = TextAnnotation, E
   /******++++++*************/
 
   // Most of the external API functions are covered in the base annotator
-  const base = createBaseAnnotator<TextAnnotation, E>(state, undoStack, opts.adapter);
+  const base = createBaseAnnotator<I, E>(state, undoStack, opts.adapter);
 
   const getUser = () => currentUser;
 
-  const setFilter = (filter?: Filter) => {
+  const setFilter = (filter?: Filter<I>) => {
     highlightRenderer.setFilter(filter);
     selectionHandler.setFilter(filter);
   }

--- a/packages/text-annotator/src/highlight/HighlightStyle.ts
+++ b/packages/text-annotator/src/highlight/HighlightStyle.ts
@@ -14,7 +14,7 @@ export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity
 }
 
 export type HighlightStyleExpression = HighlightStyle 
-  | ((annotation: TextAnnotation, state: AnnotationState, zIndex?: number) => HighlightStyle | undefined);
+  | (<I extends TextAnnotation = TextAnnotation>(annotation: I, state: AnnotationState, zIndex?: number) => HighlightStyle | undefined);
 
 export const DEFAULT_STYLE: HighlightStyle = { 
   fill: 'rgb(0, 128, 255)', 

--- a/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
@@ -17,10 +17,10 @@ export type W3CTextFormatAdapter<I extends TextAnnotation = TextAnnotation, E ex
  * @param container - the HTML container of the annotated content,
  *                    Required to locate the content's `range` within the DOM
  */
-export const W3CTextFormat = <E extends W3CTextAnnotation = W3CTextAnnotation>(
+export const W3CTextFormat =<I extends TextAnnotation = TextAnnotation, E extends W3CTextAnnotation = W3CTextAnnotation>(
   source: string,
   container: HTMLElement
-): W3CTextFormatAdapter<TextAnnotation, E> => ({
+): W3CTextFormatAdapter<I, E> => ({
   parse: (serialized) => parseW3CTextAnnotation(serialized),
   serialize: (annotation) => serializeW3CTextAnnotation(annotation, source, container)
 });
@@ -90,9 +90,9 @@ const parseW3CTextTargets = (annotation: W3CTextAnnotation) => {
   return { parsed };
 };
 
-export const parseW3CTextAnnotation = (
-  annotation: W3CTextAnnotation
-): ParseResult<TextAnnotation> => {
+export const parseW3CTextAnnotation = <I extends TextAnnotation = TextAnnotation, E extends W3CTextAnnotation = W3CTextAnnotation>(
+  annotation: E
+): ParseResult<I> => {
   const annotationId = annotation.id || uuidv4();
 
   const {
@@ -106,7 +106,7 @@ export const parseW3CTextAnnotation = (
   const bodies = parseW3CBodies(body, annotationId);
   const target = parseW3CTextTargets(annotation);
 
-  return 'error' in target
+  const parseResult = 'error' in target
     ? { error: target.error }
     : {
       parsed: {
@@ -117,10 +117,12 @@ export const parseW3CTextAnnotation = (
       }
     };
 
+  return parseResult as ParseResult<I>;
+
 };
 
-export const serializeW3CTextAnnotation = <E extends W3CTextAnnotation = W3CTextAnnotation>(
-  annotation: TextAnnotation,
+export const serializeW3CTextAnnotation = <I extends TextAnnotation = TextAnnotation, E extends W3CTextAnnotation = W3CTextAnnotation>(
+  annotation: I,
   source: string,
   container: HTMLElement
 ): E => {
@@ -171,6 +173,6 @@ export const serializeW3CTextAnnotation = <E extends W3CTextAnnotation = W3CText
     created: created?.toISOString(),
     modified: updated?.toISOString(),
     target: w3cTargets
-  } as E;
+  } as unknown as E;
 
 };


### PR DESCRIPTION
## Issue
Back in https://github.com/recogito/text-annotator-js/commit/15186ec1841df071d4153c715ff8193341900600 @rsimon added support for the internal type generic. However, there are a few points where it was left unutilized: 
- `TextAnnotatorProps` for the `TextAnnotator` React component. The issue would show up if you try to pass the `Filter<TextAnnotation>` to the `filter` prop: <img width="939" alt="image" src="https://github.com/user-attachments/assets/11313de7-0978-4f3b-a630-6acc699671a6">
- `W3CTextFormat`
- `createTextAnnotator`
- `HighlightStyleExpression`