### PR TITLE
#185 Fixed popup rendering on Android

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotationPopup/TextAnnotationPopup.tsx
+++ b/packages/text-annotator-react/src/TextAnnotationPopup/TextAnnotationPopup.tsx
@@ -93,13 +93,18 @@ export const TextAnnotationPopup = (props: TextAnnotationPopupProps) => {
   const { getFloatingProps } = useInteractions([dismiss, role]);
 
   useEffect(() => {
-    if (annotation?.id) {
+    if (!r) return;
+
+    const annotationId = annotation?.id;
+    const annotationSelectorsLength = annotation?.target.selector.length;
+
+    if (annotationId && annotationSelectorsLength) {
       const bounds = r?.state.store.getAnnotationBounds(annotation.id);
       setOpen(Boolean(bounds));
     } else {
       setOpen(false);
     }
-  }, [annotation?.id, r?.state.store]);
+  }, [annotation?.id, annotation?.target.selector, r?.state.store]);
 
   useEffect(() => {
     if (!r) return;


### PR DESCRIPTION
## Issues
See - https://github.com/recogito/text-annotator-js/issues/185#issuecomment-2545199474

In the https://github.com/recogito/text-annotator-js/pull/123 I made the popup presence check resilient to the underlying collapsed ranges in the target's selectors.

However, it caused a timing regression on Android. When the annotation is processed in the popup's `useEffect`, the `target` and its bounds aren't yet populated.
https://github.com/recogito/text-annotator-js/blob/5b9abad31724db14d473f7d363b295a967cd93b7/packages/text-annotator-react/src/TextAnnotationPopup/TextAnnotationPopup.tsx#L95-L98
![image](https://github.com/user-attachments/assets/a801107a-cff6-42c4-9538-498999d8cf95)

Also, the timing of the selection change event that populates the `target` differs on Android:
| Android | Mac |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/11beff72-9ed6-4069-a6f5-d29955364fc1) | ![image](https://github.com/user-attachments/assets/0b3b32fa-6d18-4df5-a4cf-0781a0b155d1) | 

## Changes Made
I added a check for the selectors' presence on the annotation's target. That way, the effect will react properly to their addition and re-run the bounds querying.