### PR TITLE
Added missing `adapter` forwarding to the `createSelectionState`

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -42,8 +42,7 @@ export const createTextAnnotator = <I extends TextAnnotation = TextAnnotation, E
     user: createAnonymousGuest()
   });
 
-  const state: TextAnnotatorState<I, E> =
-    createTextAnnotatorState<I, E>(container, opts.userSelectAction);
+  const state: TextAnnotatorState<I, E> = createTextAnnotatorState<I, E>(container, opts);
 
   const { selection, viewport } = state;
 

--- a/packages/text-annotator/src/state/TextAnnotatorState.ts
+++ b/packages/text-annotator/src/state/TextAnnotatorState.ts
@@ -1,4 +1,4 @@
-import type { Filter, Store, ViewportState, UserSelectActionExpression } from '@annotorious/core';
+import type { Filter, Store, ViewportState } from '@annotorious/core';
 import { 
   createHoverState, 
   createSelectionState, 
@@ -11,10 +11,12 @@ import type {
   SelectionState, 
   HoverState, 
 } from '@annotorious/core';
+
 import { createSpatialTree } from './spatialTree';
 import type { TextAnnotation, TextAnnotationTarget } from '../model';
 import type { AnnotationRects, TextAnnotationStore } from './TextAnnotationStore';
 import { isRevived, reviveAnnotation, reviveTarget } from '../utils';
+import type { TextAnnotatorOptions } from '../TextAnnotatorOptions';
 
 export interface TextAnnotatorState<I extends TextAnnotation = TextAnnotation, E extends unknown = TextAnnotation> extends AnnotatorState<I, E> {
 
@@ -30,16 +32,14 @@ export interface TextAnnotatorState<I extends TextAnnotation = TextAnnotation, E
 
 export const createTextAnnotatorState = <I extends TextAnnotation = TextAnnotation, E extends unknown = TextAnnotation>(
   container: HTMLElement,
-  defaultUserSelectAction?: UserSelectActionExpression<E>
+  opts: TextAnnotatorOptions<I, E>
 ): TextAnnotatorState<I, E> => {
 
   const store: Store<I> = createStore<I>();
 
   const tree = createSpatialTree(store, container);
 
-  // Temporary
-  const selection = createSelectionState<I, E>(store)
-  selection.setUserSelectAction(defaultUserSelectAction);
+  const selection = createSelectionState<I, E>(store, opts.userSelectAction, opts.adapter);
 
   const hover = createHoverState(store);
 


### PR DESCRIPTION
## Issue
The `createTextAnnotatorState` wasn't forwarding the provided `adapter` to the `createSelectionState`. That led to the missing serialization on the [`onUserSelect`](https://github.com/annotorious/annotorious/blob/94624c0dea045db435d30ba054a29e5c97f83d22/packages/annotorious-core/src/state/Selection.ts#L157-L164) call.

### Example
![image](https://github.com/user-attachments/assets/61d1d0cc-68aa-415b-abab-a33f11b912f8)
However, an internal type is provided to the `userSelectActionCallback`:
![image](https://github.com/user-attachments/assets/855a78e7-b847-4306-812b-4192ebcd3be3)

## Changes Made
Added `opts.adapter` forwarding to the `createSelectionState`. That makes the code compatible with the API changes made in https://github.com/annotorious/annotorious/commit/79c7b17f2002ff2dfcc93880c9048c8a73ad01e2.
I borrowed that approach from the `a9s/a9s`'s `createImageAnnotator`, which passes the whole `opts` object to the `createImageAnnotatorState`, [source](https://github.com/annotorious/annotorious/blob/94624c0dea045db435d30ba054a29e5c97f83d22/packages/annotorious/src/Annotorious.ts#L63).