### PR TITLE
#518 Added `immediateUpdatesEmit` option forwarding

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -51,7 +51,12 @@ export const createTextAnnotator = <I extends TextAnnotation = TextAnnotation, E
 
   const undoStack = createUndoStack<I>(store);
 
-  const lifecycle = createLifecycleObserver<I, E>(state, undoStack, opts.adapter);
+  const lifecycle = createLifecycleObserver<I, E>(
+    state,
+    undoStack,
+    opts.adapter,
+    { immediateUpdatesEmit: opts.immediateUpdatesEmit }
+  );
 
   let currentUser: User = opts.user;
 

--- a/packages/text-annotator/src/TextAnnotatorOptions.ts
+++ b/packages/text-annotator/src/TextAnnotatorOptions.ts
@@ -22,7 +22,12 @@ export interface TextAnnotatorOptions<I extends TextAnnotation = TextAnnotation,
   style?: HighlightStyleExpression;
 
   user?: User;
-  
+
+  /**
+   * Report annotation updates immediately
+   * both when the bodies were updated or not.
+   */
+  immediateUpdatesEmit?: boolean;
 }
 
 export type RendererType = 'SPANS' | 'CANVAS' | 'CSS_HIGHLIGHTS';
@@ -30,12 +35,8 @@ export type RendererType = 'SPANS' | 'CANVAS' | 'CSS_HIGHLIGHTS';
 export const fillDefaults = <I extends TextAnnotation = TextAnnotation, E extends unknown = TextAnnotation>(
   opts: TextAnnotatorOptions<I, E>,
   defaults: TextAnnotatorOptions<I, E>
-): TextAnnotatorOptions<I, E> => {
-
-  return {
-    ...opts,
-    annotatingEnabled: opts.annotatingEnabled ?? defaults.annotatingEnabled,
-    user: opts.user || defaults.user
-  };
-
-};
+): TextAnnotatorOptions<I, E> => ({
+  ...opts,
+  annotatingEnabled: opts.annotatingEnabled ?? defaults.annotatingEnabled,
+  user: opts.user || defaults.user
+});


### PR DESCRIPTION
## Issue
See - https://github.com/annotorious/annotorious/issues/518#issuecomment-2678403410

## Relations
This PR requires:
- https://github.com/annotorious/annotorious/pull/519

  > Added the `immediateUpdatesEmit` option to the lifecycle observer. It makes the store observer bypass the body update presence check and emit the `updateAnnotation` even immediately.