### PR TITLE
Fixed unexpected deletion of the default `r6o-annotatable` & `no-focus-outline` classes on the React `container`

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -50,7 +50,7 @@ export const TextAnnotator = <I extends TextAnnotation = TextAnnotation, E exten
   useEffect(() => anno?.setUser(user), [anno, user]);
 
   return (
-    <div ref={el} className={className}>
+    <div ref={el} className={`r6o-annotatable ${className}`}>
       {children}
     </div>
   )

--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -50,7 +50,7 @@ export const TextAnnotator = <I extends TextAnnotation = TextAnnotation, E exten
   useEffect(() => anno?.setUser(user), [anno, user]);
 
   return (
-    <div ref={el} className={`r6o-annotatable ${className}`}>
+    <div ref={el} className={`r6o-annotatable no-focus-outline ${className}`}>
       {children}
     </div>
   )


### PR DESCRIPTION
## Issue
When a consumer app uses a CSS-in-JS solution, a different `className` can be passed to the `TextAnnotator` at runtime. Unfortunately, it'll cause the deletion of the default `r6o-annotatable` class that's added only once during the renderer initialization. That way, styling for the highlights layer will be lost ⚠️
| Right after initialization | After conditionally passed `className` |
|--------|--------|
| ![CleanShot 2025-04-04 at 14 30 55](https://github.com/user-attachments/assets/dd126e0f-f02e-4f4b-abb5-9d00b4b30738) | ![CleanShot 2025-04-04 at 14 29 49](https://github.com/user-attachments/assets/247bce4d-4470-41f7-aec8-c545aed9e809) | 

## Changes Made
Cemented in the default classnames on the React annotatable container. So any custom classes will be appended to the existing ones instead of entirely overriding them.