### PR TITLE
Hide the `.r6o-span-highlight-layer` overflow

### DIFF
--- a/packages/text-annotator/src/highlight/span/spansRenderer.css
+++ b/packages/text-annotator/src/highlight/span/spansRenderer.css
@@ -6,6 +6,7 @@
   height: 100%;
   mix-blend-mode: multiply;
   pointer-events: none;
+  overflow: hidden;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Issue
When the highlight is placed on the horizontally scrollable element, the `.r6o-span-highlight-layer`, having the default `overflow: visible`, will grow beyond the width of the content and will unexpectedly make the container scrollable as well.

https://github.com/user-attachments/assets/a2af4878-e217-4e4d-ab86-27e6e0ab03b0

## Changes Made
Added a default `overflow: hidden;` to the `.r6o-span-highlight-layer` styles. That way, the highlight layer won't impact the scrollable content rendering.

###### (Soomo Staged)