### PR TITLE
Added `currentTarget` existence check before `upsertCurrentTarget` on Android

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -250,7 +250,13 @@ export const SelectionHandler = (
     if (!currentTarget || currentTarget.selector.length === 0) {
       onSelectionChange(evt);
     }
-    
+
+    /**
+     * The selection couldn't be initiated,
+     * as it might span over a not-annotatable element.
+     */
+    if (!currentTarget) return;
+
     upsertCurrentTarget();
 
     selection.userSelect(currentTarget.annotation, clonePointerEvent(evt));


### PR DESCRIPTION
## Issue
We started noticing seemingly "random" `Cannot read properties of undefined (reading 'annotation')` exceptions in our tracking tool. The common thing was that it was coming mostly from Android users.

Today, I looked through the code I found that only on Android, the `target` selection is being initiated using the `contextmenu` event:
https://github.com/recogito/text-annotator-js/blob/971e91f8dc3624f452eeab24a3301200c897c460/packages/text-annotator/src/SelectionHandler.ts#L246-L254

**_It's the only place where the `upsertCurrentTarget` is called w/o checking whether the `currentTarget` has been populated ⚠️._** 

---

I believe that's the reason behind the mentioned exceptions. That's because the `onSelectionChange` doesn't guarantee that the `currentTarget` will be populated upon execution. Inversely, the method can reset it if the selection is done over a `not-annotatable` area!
https://github.com/recogito/text-annotator-js/blob/971e91f8dc3624f452eeab24a3301200c897c460/packages/text-annotator/src/SelectionHandler.ts#L65-L66
https://github.com/recogito/text-annotator-js/blob/971e91f8dc3624f452eeab24a3301200c897c460/packages/text-annotator/src/SelectionHandler.ts#L97-L100

---

I could reproduce the error on an Android phone by selecting the `not-annotatable` area ⚠️ 

| Logs | Selection | Error |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/0d9963a1-6b52-4228-a8e4-ada444362bbe) | ![telegram-cloud-photo-size-2-5273924522287954566-y](https://github.com/user-attachments/assets/ee2a1bd7-18a1-4ce2-abcb-2dcee0240786) | ![image](https://github.com/user-attachments/assets/4d3e409a-1dc5-49a7-a193-e1793000e67e) | 