### PR TITLE
⚠️ Fixed `hovered` annotation state forwarding

### DIFF
--- a/packages/text-annotator/src/highlight/baseRenderer.ts
+++ b/packages/text-annotator/src/highlight/baseRenderer.ts
@@ -97,7 +97,11 @@ export const createBaseRenderer = <T extends TextAnnotatorState = TextAnnotatorS
       const selected = selectedIds.includes(annotation.id);
       const hovered = annotation.id === hover.current;
 
-      return { annotation, rects, state: { selected, hover: hovered }};
+      return {
+        annotation,
+        rects,
+        state: { selected, hovered }
+      };
     });
 
     renderer.redraw(highlights, bounds, currentStyle, currentPainter, lazy);


### PR DESCRIPTION
## Issue
The [`AnnotationState`](https://github.com/annotorious/annotorious/blob/f8be650c328008c45764dacdc546362f225b662f/packages/annotorious-core/src/model/AnnotationState.ts#L1-L13) provides the following props:
```ts
export interface AnnotationState {
    selected?: boolean;
    hovered?: boolean;
    custom?: {
        [key: string]: any;
    };
}
```
However, in the `text-annotator-js`, _the `hovered` is never passed_. Instead, it's the `hover`, most likely a typo. 
It's problematic when you wanna apply a style based on the `hovered` state.

###### (Soomo Staged)