### PR TITLE
#202 Added `hover` state subscription for the `redraw`

### DIFF
--- a/packages/text-annotator/src/highlight/baseRenderer.ts
+++ b/packages/text-annotator/src/highlight/baseRenderer.ts
@@ -131,6 +131,9 @@ export const createBaseRenderer = <T extends TextAnnotatorState = TextAnnotatorS
   // Refresh on selection change
   const unsubscribeSelection = selection.subscribe(() => redraw());
 
+  // Refresh on hover change
+  const unsubscribeHover = hover.subscribe(() => redraw());
+
   // Refresh on scroll
   const onScroll = () => redraw(true);
   document.addEventListener('scroll', onScroll, { capture: true, passive: true });
@@ -170,6 +173,7 @@ export const createBaseRenderer = <T extends TextAnnotatorState = TextAnnotatorS
     store.unobserve(onStoreChange);
 
     unsubscribeSelection();
+    unsubscribeHover();
 
     document.removeEventListener('scroll', onScroll);
 


### PR DESCRIPTION
## Issue
See - https://github.com/recogito/text-annotator-js/issues/202

## Changes Made
Following the `selection` subscription example
https://github.com/recogito/text-annotator-js/blob/8f46806defde7b6ef93c0d9811b4fd5c9afc9100/packages/text-annotator/src/highlight/baseRenderer.ts#L131-L132
I added `redraw` calls on the `hovered` state change. Now, the highlights can be properly styled when they are hovered:
![CleanShot 2025-06-13 at 13 46 38](https://github.com/user-attachments/assets/7beb4357-57da-46cc-8072-3da69d9937a0)
