### PR TITLE
#211 Added separate UMD vite config w/o deps exclusion

### DIFF
--- a/packages/text-annotator/package.json
+++ b/packages/text-annotator/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "start": "vite --host",
-    "build": "vite build",
+    "build": "vite build && vite build --config vite.config.umd.ts",
     "preview": "vite preview",
     "test": "vitest"
   },

--- a/packages/text-annotator/vite.config.ts
+++ b/packages/text-annotator/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { externalizeDeps } from 'vite-plugin-externalize-deps';
 
-export default defineConfig({
+const config = defineConfig({
   plugins: [
     dts({ insertTypesEntry: true, entryRoot: '.' }),
     externalizeDeps(),
@@ -14,22 +14,10 @@ export default defineConfig({
     sourcemap: true,
     lib: {
       entry: './src/index.ts',
-      name: 'RecogitoJS',
-      formats: ['es', 'umd'],
+      formats: ['es'],
       fileName: (format) => `text-annotator.${format}.js`
-    },
-    rollupOptions: {
-      output: {
-        assetFileNames: 'text-annotator.[ext]',
-        globals: {
-          'colord': 'Colord',
-          'uuid': 'UUID',
-          'dequal/lite': 'DequalLite',
-          '@annotorious/core': 'AnnotoriousCore',
-          'rbush': "RBush",
-          'hotkeys-js': 'HotkeysJs',
-        }
-      }
     }
   }
 });
+
+export default config;

--- a/packages/text-annotator/vite.config.umd.ts
+++ b/packages/text-annotator/vite.config.umd.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+
+const config = defineConfig(({
+  build: {
+    // Prevent emptying the dist folder after the previous ES build
+    emptyOutDir: false,
+    sourcemap: true,
+    lib: {
+      entry: './src/index.ts',
+      name: 'RecogitoJS',
+      formats: ['umd'],
+      fileName: (format) => `text-annotator.${format}.js`
+    }
+  }
+}));
+
+export default config;


### PR DESCRIPTION
## Issue
See - https://github.com/recogito/text-annotator-js/issues/211

In the previous https://github.com/recogito/text-annotator-js/pull/192, I added the `externalizeDeps` plugin to the `text-annotator` package bundle config. It prevents unnecessary inclusion of peer deps in the output.
However, it's relevant for the ES bundle only. On the other hand, the UMD bundle should be standalone and include pre-bundled peer deps.

## Changes Made
Added a separate `vite.config.umd.ts` config that doesn't have the `externalizeDeps` plugin.