### PR TITLE
#133 Added the `dismissOnNotAnnotatable` expression option

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -22,7 +22,7 @@ const CLICK_TIMEOUT = 300;
 
 const ARROW_KEYS = ['up', 'down', 'left', 'right'];
 
-const SELECT_ALL = isMac ? '⌘+a' :  'ctrl+a';
+const SELECT_ALL = isMac ? '⌘+a' : 'ctrl+a';
 
 const SELECTION_KEYS = [
   ...ARROW_KEYS.map(key => `shift+${key}`),
@@ -37,7 +37,7 @@ export const SelectionHandler = (
 
   let currentUser: User | undefined;
 
-  const { annotatingEnabled, offsetReferenceSelector, selectionMode } = options;
+  const { annotatingEnabled, offsetReferenceSelector, selectionMode, dismissOnNotAnnotatable } = options;
 
   const setUser = (user?: User) => currentUser = user;
 
@@ -190,9 +190,12 @@ export const SelectionHandler = (
     if (!isLeftClick) return;
 
     if (isNotAnnotatable(container, evt.target as Node)) {
-      if (options.dismissOnClickOutside)
+      const shouldDismissSelection = typeof dismissOnNotAnnotatable === 'function'
+        ? dismissOnNotAnnotatable(evt, container)
+        : dismissOnNotAnnotatable === 'ALWAYS';
+      if (shouldDismissSelection) {
         selection.clear();
-
+      }
       return;
     }
 
@@ -276,7 +279,7 @@ export const SelectionHandler = (
     if (!currentTarget || currentTarget.selector.length === 0) {
       onSelectionChange(evt);
     }
-/**
+    /**
      * The selection couldn't be initiated - might span over a not-annotatable element.
      */
     if (!currentTarget) return;
@@ -328,7 +331,7 @@ export const SelectionHandler = (
       lastDownEvent = cloneKeyboardEvent(evt);
   });
 
-  hotkeys(SELECT_ALL, { keydown: true, keyup: false}, evt => {
+  hotkeys(SELECT_ALL, { keydown: true, keyup: false }, evt => {
     lastDownEvent = cloneKeyboardEvent(evt);
     onSelectAll(evt);
   });

--- a/packages/text-annotator/src/TextAnnotatorOptions.ts
+++ b/packages/text-annotator/src/TextAnnotatorOptions.ts
@@ -9,7 +9,19 @@ export interface TextAnnotatorOptions<I extends TextAnnotation = TextAnnotation,
 
   annotatingEnabled?: boolean;
 
-  dismissOnClickOutside?: boolean;
+  /**
+   * Determines whether an active selection should be dismissed
+   * when a user ends their interaction (click, selection)
+   * on a non-annotatable element.
+   * - ALWAYS - always dismiss the selection.
+   * - ANNOTATABLE_AREAS - will dismiss selection only if you click on annotatable areas
+   *                       (inside the `container`, not marked as not-annotatable)
+   * - function - a custom matcher that takes an event and container as arguments
+   *              and returns true if the selection should be dismissed.
+   *
+   * @defaut ANNOTATABLE_AREAS
+   */
+  dismissOnNotAnnotatable?: DismissOnNotAnnotatableExpression;
 
   renderer?: RendererType;
 
@@ -28,6 +40,8 @@ export interface TextAnnotatorOptions<I extends TextAnnotation = TextAnnotation,
 }
 
 export type RendererType = 'SPANS' | 'CANVAS' | 'CSS_HIGHLIGHTS';
+
+export type DismissOnNotAnnotatableExpression = 'ALWAYS' | 'ANNOTATABLE_AREAS' | ((event: Event, container: HTMLElement) => boolean)
 
 export const fillDefaults = <I extends TextAnnotation = TextAnnotation, E extends unknown = TextAnnotation>(
   opts: TextAnnotatorOptions<I, E>,


### PR DESCRIPTION
## Issue
In the https://github.com/recogito/text-annotator-js/pull/208#issuecomment-3252905534 @rsimon and I discussed that it would be worth extending the `dismissOnClickOutside` into a more elaborate expression-like option.

> How about the following: `dismissOnClick` could have multiple values (all working titles):
> 
> * `ALWAYS` - what it says
> * `ANNOTATABLE_AREAS` - will dismiss selection only if you click on annotatable areas (inside the container, not marked as `not_annotatable`)
> * Function with the click event and (perhaps) the container element for convenience

## Changes Made
Replaced the `dismissOnClickOutside` option with the `dismissOnNotAnnotatable` that now is the aforementioned expression.