### PR TITLE
Added `react >=18.x` to the `peerDependencies` list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4856,8 +4856,8 @@
       },
       "peerDependencies": {
         "openseadragon": "^3.0.0 || ^4.0.0 || ^5.0.0",
-        "react": ">=19.x",
-        "react-dom": ">=19.x"
+        "react": ">=18.x || >=19.x",
+        "react-dom": ">=18.x || >=19.x"
       },
       "peerDependenciesMeta": {
         "openseadragon": {

--- a/packages/text-annotator-react/package.json
+++ b/packages/text-annotator-react/package.json
@@ -37,8 +37,8 @@
   },
   "peerDependencies": {
     "openseadragon": "^3.0.0 || ^4.0.0 || ^5.0.0",
-    "react": ">=19.x",
-    "react-dom": ">=19.x"
+    "react": ">=18.x || >=19.x",
+    "react-dom": ">=18.x || >=19.x"
   },
   "peerDependenciesMeta": {
     "openseadragon": {


### PR DESCRIPTION
## Issue
Recently, in the https://github.com/recogito/text-annotator-js/commit/890b08c68c5325bf9d0b157c5404093d9bf6595c, the `text-annotator-js` was migrated to React 19. One of the breaking changes was the removal of the `React 18` from the `peerDependencies` list. That caused the following exception for the consuming project on install:
<img width="1948" height="635" alt="image" src="https://github.com/user-attachments/assets/8d5739c8-077a-45d8-92de-f1d67b599775" />

## Changes Made
Added back the `react: >=18.x` to the `peerDependencies`. I tested it locally in my consuming apps, and, fortunately, I didn't face any warnings or errors 🤔 
In my app, a single `react` and `react-dom` version is used - `18.3.1`.