### PR TITLE
#218 Added preservation of a shorter element during "Block containment" handling

### DIFF
--- a/packages/text-annotator/src/utils/mergeClientRects.ts
+++ b/packages/text-annotator/src/utils/mergeClientRects.ts
@@ -1,6 +1,6 @@
 // The three topological relations we need to check for
-type Relation = 
-  // Inline elements, same height, directly adjacent
+type Relation =
+// Inline elements, same height, directly adjacent
   'inline-adjacent' |
   // Inline elements, A fully contains B
   'inline-contains' |
@@ -15,7 +15,7 @@ type Relation =
 // few shortcuts to test ONLY the situations we'll encounter
 // with text selections.
 const getRelation = (rectA: DOMRect, rectB: DOMRect): Relation | undefined => {
-  const round = (num: number ) => Math.round(num * 10) / 10;
+  const round = (num: number) => Math.round(num * 10) / 10;
 
   // Some browsers have fractional pixel differences (looking at you FF!)
   const a = {
@@ -46,7 +46,7 @@ const getRelation = (rectA: DOMRect, rectB: DOMRect): Relation | undefined => {
     // Different heights - check for containment
     if (a.top <= b.top && a.bottom >= b.bottom) {
       if (a.left <= b.left && a.right >= b.right) {
-        return 'block-contains'
+        return 'block-contains';
       }
     } else if (a.top >= b.top && a.bottom <= b.bottom) {
       if (a.left >= b.left && a.right <= b.right) {
@@ -76,7 +76,7 @@ export const mergeClientRects = (rects: DOMRect[]) => rects.reduce<DOMRect[]>((m
 
   for (const rectB of merged) {
     const relation = getRelation(rectA, rectB);
-    
+
     if (relation === 'inline-adjacent') {
       // A and B are adjacent - remove B and keep union
       next = next.map(r => r === rectB ? union(rectA, rectB) : r);
@@ -92,16 +92,22 @@ export const mergeClientRects = (rects: DOMRect[]) => rects.reduce<DOMRect[]>((m
       wasMerged = true;
       break;
     } else if (relation === 'block-contains' || relation === 'block-is-contained') {
-      // Block containment - keep the element with smaller width
+      // Block containment - keep the element with a smaller width
       if (rectA.width < rectB.width) {
         next = next.map(r => r === rectB ? rectA : r);
       }
+
+      // When the width is the same, keep the element with a smaller height
+      if (rectA.width === rectB.width && rectA.height < rectB.width) {
+        next = next.map(r => r === rectB ? rectA : r);
+      }
+
       wasMerged = true;
       break;
     }
   }
 
-  return wasMerged ? next : [ ...next, rectA ];
+  return wasMerged ? next : [...next, rectA];
 }, []);
 
 export const toDomRectList = (rects: DOMRect[]): DOMRectList => ({


### PR DESCRIPTION
## Issue
See - https://github.com/recogito/text-annotator-js/issues/218

## Changes Made
 Added preservation of a shorter element during "Block containment" handling when the widths of the rects are equal.