### PR TITLE
Rehashed lockfile with fixed `npm@11.6.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.7.8.tgz",
       "integrity": "sha512-WU//g6y6BEbPzvZNzoS147UzDdaD7x60Lr8InEDoEnzm+OwRJ9FdAm0lEQxjqlJMMzR2r8H1VE93L/u5K8Ewrw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3",
         "nanoevents": "^9.1.0",
@@ -176,6 +177,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -515,6 +517,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -561,6 +564,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1266,6 +1270,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
       "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.12"
       },
@@ -1309,6 +1314,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
       "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/color": "7.4.3",
         "@pixi/constants": "7.4.3",
@@ -1329,6 +1335,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
       "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
       }
@@ -1338,6 +1345,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
       "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -1417,6 +1425,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
       "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
@@ -1434,6 +1443,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
       "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -1524,6 +1534,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
       "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -1565,6 +1576,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
       "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/sprite": "7.4.3"
@@ -2231,6 +2243,7 @@
       "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2681,6 +2694,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3418,6 +3432,7 @@
       "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.5.4",
         "cssstyle": "^5.3.0",
@@ -3835,6 +3850,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3921,6 +3937,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3930,6 +3947,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3984,6 +4002,7 @@
       "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4418,6 +4437,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4594,6 +4614,7 @@
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4997,6 +5018,7 @@
       "name": "@recogito/text-annotator",
       "version": "3.3.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@annotorious/core": "^3.7.7",
         "colord": "^2.9.3",


### PR DESCRIPTION
## Issue
In the [11.6.1](https://docs.npmjs.com/cli/v11/using-npm/changelog#1161-2025-09-23) version there's important bug fix that resolves the `"peer": true` flag application, see - https://github.com/npm/cli/pull/8579


###### (Soomo staged, 06.10.25)