### PR TITLE
setAnnotatingMode API Function

### DIFF
--- a/packages/text-annotator/src/TextAnnotator.ts
+++ b/packages/text-annotator/src/TextAnnotator.ts
@@ -35,11 +35,15 @@ export interface TextAnnotator<I extends TextAnnotation = TextAnnotation, E exte
   // Returns true if successful (or false if the annotation is not currently rendered)
   scrollIntoView(annotationOrId: I | string, scrollParentOrId?: string | Element): boolean;
 
-  setAnnotatingEnabled: (enabled: boolean) => void;
+  setAnnotatingEnabled(enabled?: boolean): void;
+
+  setAnnotatingMode(mode?: AnnotatingMode): void;
 
   state: TextAnnotatorState<I, E>;
 
 }
+
+export type AnnotatingMode = 'CREATE_NEW' | 'ADD_TO_CURRENT'; // Possibly 'REPLACE_CURRENT' in the future
 
 export const createTextAnnotator = <I extends TextAnnotation = TextAnnotation, E extends unknown = TextAnnotation>(
   container: HTMLElement,
@@ -105,7 +109,11 @@ export const createTextAnnotator = <I extends TextAnnotation = TextAnnotation, E
     selectionHandler.setAnnotatingEnabled(
       enabled === undefined ? true : enabled
     );
-  };
+  }
+
+  const setAnnotatingMode = (mode?: AnnotatingMode) => {
+    selectionHandler.setAnnotatingMode(mode)
+  }
 
   const setFilter = (filter?: Filter<I>) => {
     highlightRenderer.setFilter(filter);
@@ -146,6 +154,7 @@ export const createTextAnnotator = <I extends TextAnnotation = TextAnnotation, E
     element: container,
     getUser,
     setAnnotatingEnabled,
+    setAnnotatingMode,
     setFilter,
     setStyle: highlightRenderer.setStyle.bind(highlightRenderer),
     redraw: highlightRenderer.redraw.bind(highlightRenderer),

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -100,6 +100,7 @@
     <div id="buttons">
       <button id="filter">Toggle Filter</button>
       <button id="fake-presence">Fake Presence</button>
+      <button id="toggle-extend-mode">Toggle Extend Mode</button>
     </div>
 
     <div id="container">
@@ -380,15 +381,15 @@
 
         var filterActive = false;
 
-        var toggleButton = document.getElementById('filter');
-        var toggleButtonLabel = toggleButton.innerText;
+        var toggleFilterButton = document.getElementById('filter');
+        var toggleFilterButtonLabel = toggleFilterButton.innerText;
 
-        toggleButton.addEventListener('click', function () {
+        toggleFilterButton.addEventListener('click', function () {
           if (filterActive) {
             r.setFilter(undefined);
 
             filterActive = false;
-            toggleButton.innerText = `${toggleButtonLabel} on`;
+            toggleFilterButton.innerText = `${toggleFilterButtonLabel} on`;
           } else {
             // Dummy filter - just filter randomly
             r.setFilter(a => {
@@ -399,7 +400,7 @@
             });
 
             filterActive = true;
-            toggleButton.innerText = `${toggleButtonLabel} off`;
+            toggleFilterButton.innerText = `${toggleFilterButtonLabel} off`;
           }
         });
 
@@ -425,7 +426,6 @@
         };
 
         var presenceButton = document.getElementById('fake-presence');
-
         presenceButton.addEventListener('click', function () {
           if (remoteSelection) {
             remoteSelection = undefined;
@@ -441,6 +441,13 @@
               callback(fakeCollaborator, [remoteSelection]);
             });
           }
+        });
+
+        var extendMode = 'CREATE_NEW';
+        var toggleExtendButton = document.getElementById('toggle-extend-mode');
+        toggleExtendButton.addEventListener('click', () => {
+          extendMode = extendMode === 'CREATE_NEW' ? 'ADD_TO_CURRENT' : 'CREATE_NEW';
+          r.setAnnotatingMode(extendMode);
         });
 
         // Make global so we can manipulate from the console


### PR DESCRIPTION
## In this PR

This PR adds a new API function to the annotator: `setAnnotatingMode`.

```ts
setAnnotatingMode(mode?: 'CREATE_NEW' | 'ADD_TO_CURRENT'): void;
```

This function complements the recently added `allowModifierSelect` init arg.

While `allowModifierSelect` lets users extend existing annotations by holding down the modifier key (`CTRL` or `Cmd` on Mac), `setAnnotatingMode` gives host applications a way to enable the same behavior programmatically–independent of the `allowModifierSelect` setting.

- `CREATE_NEW` (default): each user selection creates a new annotation.
- `ADD_TO_CURRENT`: if a (single) annotation is currently selected, a user selection extends the current annotation.