### PR TITLE
Re-run the `npm i` using `npm@11.6.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
       "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.7.13.tgz",
       "integrity": "sha512-ZAtjqKqWpG+l32YwIMAqCVukK+S1cYRlFsqRWvnOVaGBEaldkFSzhX1zxspz46OXN3jvxGw1LsJFehaLFm1lPg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3",
         "nanoevents": "^9.1.0",
@@ -184,7 +183,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -524,7 +522,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -568,7 +565,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1144,7 +1140,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
       "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.12"
       },
@@ -1188,7 +1183,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
       "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pixi/color": "7.4.3",
         "@pixi/constants": "7.4.3",
@@ -1209,7 +1203,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
       "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
       }
@@ -1219,7 +1212,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
       "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -1299,7 +1291,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
       "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
@@ -1317,7 +1308,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
       "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -1408,7 +1398,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
       "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -1450,7 +1439,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
       "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/sprite": "7.4.3"
@@ -1958,7 +1946,6 @@
       "integrity": "sha512-keKxkZMqnDicuvFoJbzrhbtdLSPhj/rZThDlKWCDbgXmUg0rEUFtRssDXKYmtXluZlIqiC5VqkCgRwzuyLHKHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2172,7 +2159,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3142,7 +3128,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3152,7 +3137,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3633,7 +3617,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -3941,7 +3924,6 @@
       "name": "@recogito/text-annotator",
       "version": "3.4.9",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@annotorious/core": "^3.7.13",
         "colord": "^2.9.3",


### PR DESCRIPTION
## Issue
The [11.6.3 release](https://github.com/npm/cli/releases/tag/v11.6.3) includes a few important bug fixes, specifically, fixing the dependencies flag calculation:
> [b1aee62](https://github.com/npm/cli/commit/b1aee62082d7b25ec07f64e906afd76840907fbd) [#8645](https://github.com/npm/cli/pull/8645) dep flag calculation ([#8645](https://github.com/npm/cli/pull/8645)) ([@liamcmitchell](https://github.com/liamcmitchell))