### PR TITLE
Fixed programmatically focusable `tabindex` assignment

### DIFF
--- a/packages/text-annotator/src/utils/programmaticallyFocusable.ts
+++ b/packages/text-annotator/src/utils/programmaticallyFocusable.ts
@@ -4,7 +4,7 @@
  * It's required to process keyboard events on an element that is not natively focusable.
  */
 export const programmaticallyFocusable = (container: HTMLElement) => {
-  if (!container.hasAttribute('tabindex') && container.tabIndex < 0) {
+  if (!container.hasAttribute('tabindex') || container.tabIndex < -1) {
     container.setAttribute('tabindex', '-1');
   }
 


### PR DESCRIPTION
## Issue
I noticed a mistake in the `tabindex` assignment logic. The attribute was assigned if an element didn't have it _AND the `tabIndex` is less than 0_. The latter can't be judged reliably if there's no `tabindex` on an element 🤷🏻‍♂️ 