### PR TITLE
Fixed accessing `undefined` `currentTarget` during the right-click selection

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -184,7 +184,22 @@ export const createSelectionHandler = (
       }
     }
 
-    if (!currentTarget) onSelectStart();
+    /*
+     Let's assume the user drags the selection from outside the annotatable area
+     over the annotatable area (intersection!). Then drags it out again
+     (no intersection!), then in again (intersection). Because the
+     currentTarget will have been cleared, meanwhile, execution will stop.
+
+     But we don't want this - instead, processing should continue as normal,
+     and a new currentTarget should be computed when the user drags the
+     selection into the annotatable area a second time.
+    */
+    if (!currentTarget) {
+      onSelectStart();
+
+      // If the currentTarget is still missing -> bail out
+      if (!currentTarget) return;
+    }
 
     if (sel.isCollapsed) {
       /**


### PR DESCRIPTION
## Context
In our app, we noticed an irregular spike of the following exception reports:
> `Uncaught TypeError: Cannot read properties of undefined (reading 'annotation')`

It can be consistently reproduced if a user "selects" a word by clicking the right mouse button:
<img height="400" alt="CleanShot 2025-11-26 at 17 21 28" src="https://github.com/user-attachments/assets/e5554980-80c7-4716-9b9b-804f04c9d09e" />

## Issue
I noticed that the handling for `currentTarget: undefined` was accidentally removed in `SelectionHandler` in https://github.com/recogito/text-annotator-js/commit/1c34de0d879e7c2d8379d0305c8c48d1bde2c468.
There, an ability to start a selection from a `not-annotatable` element was added by manually calling `onSelectStart` when the `currentTarget` is missing.
Although the `currentTarget` can still be missing upon the call when either annotating isn't enabled _OR the selection is caused by the right click_ ⚠️
https://github.com/recogito/text-annotator-js/blob/cc0438ed0d10bb4118248960daeb2579e31a014f/packages/text-annotator/src/SelectionHandler.ts#L97-L100

## Changes Made
Added the bailout when `currentTarget` is missing, even after calling `onSelectStart`.
Additionally, I restored the explanatory comment. It's really helpful and provides a context for a not immediately obvious process.