### PR TITLE
Added `userSelectAction` forwarding through the `TextAnnotator` component

### DIFF
--- a/packages/text-annotator-react/src/TextAnnotator.tsx
+++ b/packages/text-annotator-react/src/TextAnnotator.tsx
@@ -1,7 +1,7 @@
 import { JSX, ReactNode, useContext, useEffect, useRef } from 'react';
 import { AnnotoriousContext, Filter } from '@annotorious/react';
 import type { FormatAdapter } from '@annotorious/core';
-import type { AnnotatingMode, HighlightStyleExpression, TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
+import type { AnnotatingMode, TextAnnotation, TextAnnotatorOptions } from '@recogito/text-annotator';
 import { createTextAnnotator } from '@recogito/text-annotator';
 
 import '@recogito/text-annotator/text-annotator.css';
@@ -28,7 +28,7 @@ export const TextAnnotator = <I extends TextAnnotation = TextAnnotation, E exten
 
   const { className, children, ...opts } = props;
 
-  const { style, filter, user, annotatingEnabled, annotatingMode } = opts;
+  const { style, filter, user, annotatingEnabled, userSelectAction, annotatingMode } = opts;
 
   const { anno, setAnno } = useContext(AnnotoriousContext);
 
@@ -48,6 +48,8 @@ export const TextAnnotator = <I extends TextAnnotation = TextAnnotation, E exten
   useEffect(() => anno?.setFilter(filter), [anno, filter]);
 
   useEffect(() => anno?.setUser(user), [anno, user]);
+
+  useEffect(() => anno?.setUserSelectAction(userSelectAction), [anno, userSelectAction]);
 
   useEffect(() => anno?.setAnnotatingEnabled(annotatingEnabled), [anno, annotatingEnabled]);
 


### PR DESCRIPTION
## Issue
The `anno?.setUserSelectAction` was originally added in the https://github.com/recogito/text-annotator-js/pull/126. Yet it was accidentally removed during the conflict resolution in https://github.com/recogito/text-annotator-js/pull/126/commits/1e5ada494085f701d6adbba38005e5c9715269d9

Instead, the `userSelectAction` should be forwarded to the annotated instance through the `TextAnnotator` component, as the rest of the interactive props.