### PR TITLE
#244 Made the hijacking check cover cases when editor is within explicitly `not-annotatable` elements

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -17,7 +17,8 @@ import {
   isRangeWhitespaceOrEmpty,
   trimRangeToContainer,
   isNotAnnotatable,
-  mergeRanges
+  mergeRanges,
+  isRangeAnnotatable
 } from './utils';
 
 const CLICK_TIMEOUT = 300;
@@ -160,7 +161,7 @@ export const createSelectionHandler = (
      * another element in a not-annotatable area. A rare case in practice.
      * But rich text editors like Quill will do it!
      */
-    if (!selectionRanges.some(r => r.intersectsNode(container))) {
+    if (selectionRanges.every(r => !isRangeAnnotatable(container, r))) {
       currentTarget = undefined;
       return;
     }


### PR DESCRIPTION
## Issue
Fixes the https://github.com/recogito/text-annotator-js/issues/244

## Changes Made
Made the hijacking check stricter by dismissing the selection made entirely within the not-annotatable element, even if it's within the `container`.