### PR TITLE
Added selection reset on arrow press when captured on an annotatable element

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -478,7 +478,7 @@ export const createSelectionHandler = (
   const handleArrowKeyPress = (evt: KeyboardEvent) => {
     if (
       evt.repeat ||
-      evt.target !== container && evt.target !== document.body
+      evt.target instanceof Node && isNotAnnotatable(container, evt.target) && evt.target !== document.body
     ) {
       return;
     }


### PR DESCRIPTION
## Issue
I noticed an irregular behavior when I tab to a focusable, but annotatable element, and press an arrow key. Instead of resetting the `currentTarget`, it preserves the deleted annotation id until I reach the text:

https://github.com/user-attachments/assets/6940e178-40ba-49c9-b355-58da76c219e9

It was caused by the `keydown`'s `event.target` pointing at an internal element of the `container`, but not the `container` itself. Which doesn't satisfy the following condition:
https://github.com/recogito/text-annotator-js/blob/db57e5b36999d0f5871c0d2325abecc0403dd977/packages/text-annotator/src/SelectionHandler.ts#L478-L484 

## Changes Made
Made the `currentTarget` to reset on an arrow press within any annotatable element.