### PR TITLE
#247 Fixed keyboard selection in Firefox & Safari after user navigates with the `Tab`

### DIFF
--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -417,12 +417,33 @@ export const createSelectionHandler = (
     selection.userSelect(currentTarget.annotation, clonePointerEvent(evt));
   }
 
+  /**
+   * Handles the completion of keyboard-based text selection when the Shift key is released.
+   *
+   * When a non-collapsed selection exists upon Shift key release, this handler persists
+   * the annotation to the store and programmatically selects it.
+   *
+   * Event handling is restricted to:
+   * - Annotatable elements within the container
+   * - The document body (which receives focus during Tab navigation in Firefox and Safari)
+   *
+   * @see https://github.com/recogito/text-annotator-js/issues/247
+   */
   const onKeyup = (evt: KeyboardEvent) => {
     if (!currentAnnotatingEnabled) return;
 
+    if (
+      evt.repeat ||
+      (
+        evt.target instanceof Node && isNotAnnotatable(container, evt.target) &&
+        evt.target !== document.body
+      )
+    ) {
+      return;
+    }
+
     if (evt.key === 'Shift' && currentTarget) {
       const sel = document.getSelection();
-
       if (!sel.isCollapsed) {
         upsertCurrentTarget();
         selection.userSelect(currentTarget.annotation, cloneKeyboardEvent(evt));
@@ -516,7 +537,7 @@ export const createSelectionHandler = (
   document.addEventListener('pointerup', onPointerUp);
   document.addEventListener('contextmenu', onContextMenu);
 
-  container.addEventListener('keyup', onKeyup);
+  document.addEventListener('keyup', onKeyup);
   container.addEventListener('selectstart', onSelectStart);
   document.addEventListener('selectionchange', onSelectionChange);
 
@@ -532,7 +553,7 @@ export const createSelectionHandler = (
     document.removeEventListener('pointerup', onPointerUp);
     document.removeEventListener('contextmenu', onContextMenu);
 
-    container.removeEventListener('keyup', onKeyup);
+    document.removeEventListener('keyup', onKeyup);
     container.removeEventListener('selectstart', onSelectStart);
     document.removeEventListener('selectionchange', onSelectionChange);
 

--- a/packages/text-annotator/src/SelectionHandler.ts
+++ b/packages/text-annotator/src/SelectionHandler.ts
@@ -489,17 +489,23 @@ export const createSelectionHandler = (
   });
 
   /**
-   * Free caret movement through the text resets the annotation selection.
+   * Clears the current annotation selection when the user moves the text caret using arrow keys.
    *
-   * It should be handled only on:
-   * - the annotatable `container`, where the text is.
-   * - the `body`, where the focus goes when user closes the popup,
-   *   or clicks the button that gets unmounted, e.g. "Close"
+   * This handler resets the selection state to ensure that free caret navigation through the text
+   * does not inadvertently maintain an active annotation selection.
+   *
+   * Event handling is restricted to:
+   * - Annotatable elements within the container
+   * - The document body (which receives focus when the popup is closed or when interacting
+   *   with elements that become unmounted, such as a "Close" button)
    */
   const handleArrowKeyPress = (evt: KeyboardEvent) => {
     if (
       evt.repeat ||
-      evt.target instanceof Node && isNotAnnotatable(container, evt.target) && evt.target !== document.body
+      (
+        evt.target instanceof Node && isNotAnnotatable(container, evt.target) &&
+        evt.target !== document.body
+      )
     ) {
       return;
     }


### PR DESCRIPTION
## Issue
Fixes https://github.com/recogito/text-annotator-js/issues/247

## Changes Made
Following an example of the `handleArrowKeyPress`, I added `keyup` event handling to the `document` level. It will properly capture keyboard selection in Firefox/Safari after a user moves their focus with the `Tab`.

## Relations
This PR depends on:
- https://github.com/recogito/text-annotator-js/pull/246