### PR TITLE
Fixed breaking UTF-16 code units when collecting `target`'s `prefix` / `suffix`

### DIFF
--- a/packages/text-annotator/src/utils/getQuoteContext.ts
+++ b/packages/text-annotator/src/utils/getQuoteContext.ts
@@ -1,8 +1,10 @@
 import { getRangeAnnotatableContents } from './splitAnnotatableRanges';
 
+const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
 export const getQuoteContext = (
-  range: Range, 
-  container: HTMLElement, 
+  range: Range,
+  container: HTMLElement,
   length = 10,
   offsetReferenceSelector?: string
 ) => {
@@ -15,7 +17,7 @@ export const getQuoteContext = (
   rangeBefore.setEnd(range.startContainer, range.startOffset);
 
   const before = getRangeAnnotatableContents(rangeBefore).textContent;
-  
+
   const rangeAfter = document.createRange();
   rangeAfter.setStart(range.endContainer, range.endOffset);
 
@@ -26,8 +28,11 @@ export const getQuoteContext = (
 
   const after = getRangeAnnotatableContents(rangeAfter).textContent;
 
+  const prefixGraphemes = [...segmenter.segment(before)];
+  const suffixGraphemes = [...segmenter.segment(after)];
+
   return {
-    prefix: before.substring(before.length - length),
-    suffix: after.substring(0, length)
-  }
+    prefix: prefixGraphemes.slice(-length).map(s => s.segment).join(''),
+    suffix: suffixGraphemes.slice(0, length).map(s => s.segment).join('')
+  };
 }


### PR DESCRIPTION
## Consumer Issue
The JSON parser chokes on this fragment within an annotation's `TextQuoteSelector`:
```
"suffix": "\n  𝜌=Σ⁡(\ud835"
```
That causes an exception to be thrown when the annotation is attempted to be stored on the server.


## Copilot Summary
This pull request updates the `getQuoteContext` utility function to improve how it handles text segments, ensuring accurate processing of complex Unicode characters such as emojis and accented letters. Instead of using simple string slicing, it now segments text by grapheme clusters, which represent user-perceived characters.

**Unicode and text handling improvements:**

* Introduced `Intl.Segmenter` with `granularity: 'grapheme'` to properly segment text into grapheme clusters, enabling correct handling of complex characters. (`packages/text-annotator/src/utils/getQuoteContext.ts`)
* Updated the logic in `getQuoteContext` to use grapheme-based slicing for `prefix` and `suffix`, replacing the previous substring approach. This ensures that the returned context does not split characters in the middle. (`packages/text-annotator/src/utils/getQuoteContext.ts`)

## Visual breakdown
ChatGPT collected a pretty clear demo on why using the `.slice` or `.substring` on a complex string containing UTF-16 might be problematic: https://chatgpt.com/canvas/shared/69cbdde0d4848191a8f176f7b15ff576

###### (Soomo Staged 31.03.26)