### PR TITLE
Fixed unexpected overselection on iOS when a user starts selection from the gutter

### DIFF
--- a/packages/text-annotator/src/highlight/span/spansRenderer.css
+++ b/packages/text-annotator/src/highlight/span/spansRenderer.css
@@ -7,6 +7,7 @@
   mix-blend-mode: multiply;
   pointer-events: none;
   overflow: hidden;
+  user-select: none;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Issue
I noticed that if the `span` highlights contain some entries, starting selection from the gutter may cause Safari to go wild with the handlebars:

https://github.com/user-attachments/assets/465d2c3b-e264-4eb3-8ce5-b3404bcc4010

## Changes Made
Added explicit `user-select: none;` for the `.r6o-span-highlight-layer` element. That made the selection more predictable in iOS.

###### Soomo Staged (22.04.26)