### PR TITLE
Added safari-specific `user-select` prop

### DIFF
--- a/packages/text-annotator/src/highlight/span/spansRenderer.css
+++ b/packages/text-annotator/src/highlight/span/spansRenderer.css
@@ -8,6 +8,7 @@
   pointer-events: none;
   overflow: hidden;
   user-select: none;
+  -webkit-user-select: none; /* Safari doesn't support regular `user-select` */
   z-index: 1;
 }
 


### PR DESCRIPTION
## Issue
In the previous https://github.com/recogito/text-annotator-js/pull/253, I only added the `user-select: none;` to the `.r6o-span-highlight-layer` stylesheet. 

Unfortunately, _it's not enough for Safari_. According to [caniuse](https://caniuse.com/user-select-none), the `-webkit-user-select` is required too. Additionally, I verified it in [a playground](https://developer.mozilla.org/en-US/play?id=nQY6XgAQEstXLftCT3SCE5c7vGk%2BIFmRZydDQMtIAFi%2B%2BFpGM5KoXFC6OkHrPsjFGScqMeoLohm7MQdk).

Unfortunately, I missed that due to my local testing environment. I checked the results in my app, using the `@emotion/css` library that automatically polyfills such properties.

###### Soomo Staged (22.04.26)