### PR TITLE
#255 Moved `.r6o-span-highlight-layer` rendering to the end of the `container`

### DIFF
--- a/packages/text-annotator/src/highlight/span/spansRenderer.ts
+++ b/packages/text-annotator/src/highlight/span/spansRenderer.ts
@@ -34,7 +34,7 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
   const highlightLayer = document.createElement('div');
   highlightLayer.className = 'r6o-span-highlight-layer';
 
-  container.insertBefore(highlightLayer, container.firstChild);
+  container.appendChild(highlightLayer);
 
   // Currently rendered highlights
   let currentRendered: Highlight[] = [];


### PR DESCRIPTION
## Issue
Resolves https://github.com/recogito/text-annotator-js/issues/255

## Changes Made
Replaced the `.insertBefore` with the `.appendChild`, so the `highlightLayer` will be rendered after the last child of the `container`.

###### Soomo Staged (22.04.26)