### PR TITLE
Rendering Performance: Quick Wins

### DIFF
--- a/packages/text-annotator-tei/src/crosswalk/utils/reanchor.ts
+++ b/packages/text-annotator-tei/src/crosswalk/utils/reanchor.ts
@@ -3,9 +3,9 @@ export const reanchor = (originalNode: Node, parentNode: Node, originalOffset: n
 
   let offset = originalOffset;
 
-  const it = document.createNodeIterator(parentNode, NodeFilter.SHOW_TEXT);
+  const walker = document.createTreeWalker(parentNode, NodeFilter.SHOW_TEXT);
 
-  let currentNode = it.nextNode();
+  let currentNode = walker.nextNode();
 
   let run = true;
 
@@ -19,7 +19,7 @@ export const reanchor = (originalNode: Node, parentNode: Node, originalOffset: n
       }
     }
 
-    currentNode = it.nextNode();
+    currentNode = walker.nextNode();
   } while (currentNode && run);
 
   return { node, offset };

--- a/packages/text-annotator/src/utils/annotation/revive-annotation.ts
+++ b/packages/text-annotator/src/utils/annotation/revive-annotation.ts
@@ -19,7 +19,7 @@ export const reviveSelector = <T extends TextSelector>(selector: T, container: H
 
   const offsetReference = selector.offsetReference || container;
 
-  const iterator = document.createNodeIterator(container, NodeFilter.SHOW_TEXT, (node) =>
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, (node) =>
     node.parentElement?.closest(NOT_ANNOTATABLE_SELECTOR)
       ? NodeFilter.FILTER_SKIP
       : NodeFilter.FILTER_ACCEPT
@@ -30,7 +30,7 @@ export const reviveSelector = <T extends TextSelector>(selector: T, container: H
 
   const range = document.createRange();
 
-  let n = iterator.nextNode();
+  let n = walker.nextNode();
   if (n === null) console.error('Could not revive annotation target. Content missing.');
 
   // If there's no offset reference, start immediately
@@ -49,7 +49,7 @@ export const reviveSelector = <T extends TextSelector>(selector: T, container: H
       runningOffset += len;
     }
 
-    n = iterator.nextNode();
+    n = walker.nextNode();
   }
 
   // set range end
@@ -63,7 +63,7 @@ export const reviveSelector = <T extends TextSelector>(selector: T, container: H
 
     runningOffset += len;
 
-    n = iterator.nextNode();
+    n = walker.nextNode();
   }
   
   return {
@@ -72,7 +72,6 @@ export const reviveSelector = <T extends TextSelector>(selector: T, container: H
   }
 
 }
-
 
 export const reviveTarget = <T extends TextAnnotationTarget = TextAnnotationTarget>(target: T, container: HTMLElement): T =>
   isRevived(target.selector)

--- a/packages/text-annotator/src/utils/dom/split-annotatable-ranges.ts
+++ b/packages/text-annotator/src/utils/dom/split-annotatable-ranges.ts
@@ -1,7 +1,7 @@
 import { isRangeAnnotatable, NOT_ANNOTATABLE_CLASS, NOT_ANNOTATABLE_SELECTOR } from '../dom';
 
 const iterateNotAnnotatableElements = function*(range: Range): Generator<HTMLElement> {
-  const notAnnotatableIterator = document.createNodeIterator(
+  const notAnnotatableIterator = document.createTreeWalker(
     range.commonAncestorContainer,
     NodeFilter.SHOW_ELEMENT,
     (node) =>

--- a/packages/text-annotator/src/utils/highlight/get-highlight-client-rects.ts
+++ b/packages/text-annotator/src/utils/highlight/get-highlight-client-rects.ts
@@ -62,19 +62,15 @@ export const getHighlightClientRects = (range: Range) => {
     }
 
     // Text nodes have no .getClientRects()!
-    const getTextClientRects = (t: Text[]) => {
-      if (t.length === 0) return [];
-
+    const getTextClientRects = (t: Text) => {
       const r = document.createRange();
-      r.setStartBefore(t[0]);
-      r.setEndAfter(t[t.length - 1]);
-
+      r.selectNode(t);
       return Array.from(r.getClientRects());
     }
 
     return [
       ...Array.from(firstRange.getClientRects()),
-      ...getTextClientRects(textNodes.slice(1, -1)),
+      ...textNodes.slice(1, -1).flatMap(getTextClientRects),
       ...Array.from(lastRange.getClientRects())
     ];
   }

--- a/packages/text-annotator/src/utils/highlight/get-highlight-client-rects.ts
+++ b/packages/text-annotator/src/utils/highlight/get-highlight-client-rects.ts
@@ -62,15 +62,19 @@ export const getHighlightClientRects = (range: Range) => {
     }
 
     // Text nodes have no .getClientRects()!
-    const getTextClientRects = (t: Text) => {
+    const getTextClientRects = (t: Text[]) => {
+      if (t.length === 0) return [];
+
       const r = document.createRange();
-      r.selectNode(t);
+      r.setStartBefore(t[0]);
+      r.setEndAfter(t[t.length - 1]);
+
       return Array.from(r.getClientRects());
     }
 
     return [
       ...Array.from(firstRange.getClientRects()),
-      ...textNodes.slice(1, -1).flatMap(getTextClientRects),
+      ...getTextClientRects(textNodes.slice(1, -1)),
       ...Array.from(lastRange.getClientRects())
     ];
   }

--- a/packages/text-annotator/src/utils/highlight/get-highlight-client-rects.ts
+++ b/packages/text-annotator/src/utils/highlight/get-highlight-client-rects.ts
@@ -1,21 +1,30 @@
 export const getHighlightClientRects = (range: Range) => {
   const textNodes: Text[] = [];
 
-  // Get all text nodes inside the range's commonAncestorContainer
-  const it = document.createNodeIterator(
+  // Get all text nodes inside the range's commonAncestorContainer.
+  // Note that treeWalker is known to be faster than NodeIterator!
+  const walker = document.createTreeWalker(
     range.commonAncestorContainer, 
     NodeFilter.SHOW_TEXT);
 
-  /*
-   Filter text nodes that intersect the range. Note that we could
-   also include this filter in the node iterator directly.
-   But the while loop is faster (!) - possibly due to a function call overhead.
-  */
-  let currentNode: Text | undefined;
+  // Filter text nodes that intersect the range.
+  if (range.startContainer.nodeType === Node.TEXT_NODE) {
+    walker.currentNode = range.startContainer;
+    if (range.intersectsNode(range.startContainer)) {
+      textNodes.push(range.startContainer as Text);
+    }
+  }
+
+  let started = textNodes.length > 0;
+  let currentNode: Text;
  
-  while ((currentNode = it.nextNode() as Text)) {
+  while ((currentNode = walker.nextNode() as Text)) {
     if (range.intersectsNode(currentNode)) {
+      started = true;
       textNodes.push(currentNode);
+    } else if (started) {
+      // Break early
+      break;
     }
   }
 

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -175,6 +175,8 @@
           he not propitiate you with many a burnt sacrifice? Why then should you keep on being so angry with him?"
         </p>
 
+        <h2>Block!</h2>
+
         <p>
           And Jove said, "My child, what are you talking about? How can I forget Ulysses than whom there is no more
           capable man on earth, nor more liberal in his offerings to the immortal gods that live in heaven? Bear in mind,

--- a/packages/text-annotator/test/index.html
+++ b/packages/text-annotator/test/index.html
@@ -175,7 +175,7 @@
           he not propitiate you with many a burnt sacrifice? Why then should you keep on being so angry with him?"
         </p>
 
-        <h2>Block!</h2>
+        <h2>Block Subheading</h2>
 
         <p>
           And Jove said, "My child, what are you talking about? How can I forget Ulysses than whom there is no more


### PR DESCRIPTION
## In this PR

We're seeing performance limitations on large annotated TEI/XML files. (Large meaning, either, "large filesize and complex markup" and / or "many 100s of annotations.)

Making them work smoothly will require a slightly deeper architecture change, to make the core ([text-annotator-state](https://github.com/recogito/text-annotator-js/blob/764b8938b303cf6160855edbb1d4cfed96c174e6/packages/text-annotator/src/state/text-annotator-state.ts) and [spatial-tree](https://github.com/recogito/text-annotator-js/blob/764b8938b303cf6160855edbb1d4cfed96c174e6/packages/text-annotator/src/state/spatial-tree.ts)) support actual lazy rendering.

But before we do that, here are some smaller "quick wins" that are easy to implement, don't impact the current architecture, and already provide a bit of a performance boost.

### Changes

- Replaced uses of NodeIterator with TreeWalker, which is described as faster in various places (see e.g. [here](https://stackoverflow.com/questions/64551229/queryselectorall-vs-nodeiterator-vs-treewalker-fastest-pure-js-flat-dom-iterat)). Probably not a huge impact, but worth doing.
- Main bottleneck addressed: [get-highlight-client-rects](https://github.com/recogito/text-annotator-js/blob/764b8938b303cf6160855edbb1d4cfed96c174e6/packages/text-annotator/src/utils/highlight/get-highlight-client-rects.ts) was wasting lots of loop iterations. The loop now:
  - skips to the start position immediately
  - breaks early when the end position is reached