### PR TITLE
#263 Added selection preservation, even if it protrudes beyond the `container`

### DIFF
--- a/packages/text-annotator/src/selection-handler.ts
+++ b/packages/text-annotator/src/selection-handler.ts
@@ -155,12 +155,15 @@ export const createSelectionHandler = <T extends TextAnnotation>(
     const selectionRanges =
       Array.from(Array(sel.rangeCount).keys()).map(idx => sel.getRangeAt(idx));
 
+    const containedRanges =
+      selectionRanges.map(r => trimRangeToContainer(r, container));
+
     /**
      * This is to handle cases where the selection is "hijacked" by
      * another element in a not-annotatable area. A rare case in practice.
      * But rich text editors like Quill will do it!
      */
-    if (selectionRanges.every(r => !isRangeAnnotatable(container, r))) {
+    if (containedRanges.every(r => !isRangeAnnotatable(container, r))) {
       currentTarget = undefined;
       return;
     }
@@ -219,10 +222,6 @@ export const createSelectionHandler = <T extends TextAnnotation>(
       return;
     }
 
-    const containedRanges =
-      selectionRanges.map(r => trimRangeToContainer(r, container));
-
-    // The selection should be captured only within the annotatable container
     if (containedRanges.every(r => isRangeWhitespaceOrEmpty(r))) return;
 
     const annotatableRanges = containedRanges.flatMap(r => splitAnnotatableRanges(container, r.cloneRange()));

--- a/packages/text-annotator/src/selection-handler.ts
+++ b/packages/text-annotator/src/selection-handler.ts
@@ -155,6 +155,7 @@ export const createSelectionHandler = <T extends TextAnnotation>(
     const selectionRanges =
       Array.from(Array(sel.rangeCount).keys()).map(idx => sel.getRangeAt(idx));
 
+    // The selection should be captured only within the annotatable container
     const containedRanges =
       selectionRanges.map(r => trimRangeToContainer(r, container));
 
@@ -222,6 +223,11 @@ export const createSelectionHandler = <T extends TextAnnotation>(
       return;
     }
 
+    /**
+     * The DOM layout may contain collapsed `\n`.
+     * Ranges covering those symbols should be ignored.
+     * @see https://github.com/recogito/text-annotator-js/pull/227
+     */
     if (containedRanges.every(r => isRangeWhitespaceOrEmpty(r))) return;
 
     const annotatableRanges = containedRanges.flatMap(r => splitAnnotatableRanges(container, r.cloneRange()));


### PR DESCRIPTION
## Issue
Fixes https://github.com/recogito/text-annotator-js/issues/263

## Changes Made
Added range trimming to the start of the selection processing. That ensures the selection made on the `container` will still get preserved. It should pass the `isRangeAnnotatable` check.

That way, the mixed selection won't be unexpectedly dismissed.

## Demo

https://github.com/user-attachments/assets/39338ca3-30b3-482c-8e54-85d2cbecd262

## Relations
This change is related to the following PR, where any content outside the `container` is treated as `not-annotatable`:
- https://github.com/recogito/text-annotator-js/pull/208

###### Soomo Staged 21.05.26