### PR TITLE
[JUNK] Added generic type parameter to `HighlightStyleExpression`

### DIFF
--- a/packages/pdf-annotator-react/src/pdf-annotator.tsx
+++ b/packages/pdf-annotator-react/src/pdf-annotator.tsx
@@ -12,7 +12,7 @@ export type PDFAnnotatorProps = TextAnnotatorOptions<PDFAnnotation, PDFAnnotatio
 
   filter?: Filter;
 
-  style?: HighlightStyleExpression
+  style?: HighlightStyleExpression<PDFAnnotation>
 
   pdfUrl: string;
 

--- a/packages/pdf-annotator/src/pdf-annotator.ts
+++ b/packages/pdf-annotator/src/pdf-annotator.ts
@@ -32,7 +32,7 @@ export interface PDFAnnotator extends Omit<TextAnnotator<PDFAnnotation, PDFAnnot
 
   setScale(scale: PDFScale | number): number;
 
-  setStyle(style?: HighlightStyleExpression, id?: string): void;
+  setStyle(style?: HighlightStyleExpression<PDFAnnotation>, id?: string): void;
 
   zoomIn(percentage?: number): number;
 
@@ -137,7 +137,7 @@ export const createPDFAnnotator = (
     }
   }
 
-  const setStyle = (style: HighlightStyleExpression | undefined, id?: string) =>
+  const setStyle = (style: HighlightStyleExpression<PDFAnnotation> | undefined, id?: string) =>
     renderer.setStyle(style, id);
 
   const setUser = (user: User) => {

--- a/packages/text-annotator/src/rendering/base-renderer.ts
+++ b/packages/text-annotator/src/rendering/base-renderer.ts
@@ -17,7 +17,7 @@ import { debounce } from '../utils/events';
 /**
  * The renderer runtime interface.
  */
-export interface Renderer {
+export interface Renderer<I extends TextAnnotation = TextAnnotation> {
 
   destroy(): void;
 
@@ -25,7 +25,7 @@ export interface Renderer {
 
   redraw(force?: boolean): void;
 
-  setStyle(style?: HighlightStyleExpression, id?: string): void;
+  setStyle(style?: HighlightStyleExpression<I>, id?: string): void;
 
   setFilter(filter?: Filter<any>): void;
 
@@ -54,15 +54,15 @@ export type RendererFactory<T extends Annotation> = (
  * implementers can simply implement a painter, and wrap it in the
  * BaseRenderer, which will handle common concerns.
  */
-export interface Painter {
+export interface Painter<I extends TextAnnotation = TextAnnotation> {
 
   destroy(): void;
 
   redraw(
-    highlights:Highlight[], 
-    bounds: ViewportBounds, 
-    style?: HighlightStyleExpression,
-    styleOverrides?: Map<string, HighlightStyleExpression>,
+    highlights: Highlight[],
+    bounds: ViewportBounds,
+    style?: HighlightStyleExpression<I>,
+    styleOverrides?: Map<string, HighlightStyleExpression<I>>,
     force?: boolean
   ): void;
 
@@ -70,19 +70,19 @@ export interface Painter {
 
 }
 
-export const createRenderer = <T extends TextAnnotatorState = TextAnnotatorState<TextAnnotation, any>> (
-  painter: Painter,
-  container: HTMLElement, 
+export const createRenderer = <T extends TextAnnotatorState = TextAnnotatorState<TextAnnotation, any>, I extends TextAnnotation = TextAnnotation>(
+  painter: Painter<I>,
+  container: HTMLElement,
   state: T,
   viewport: ViewportState,
-): Renderer => {
+): Renderer<I> => {
   const { store, selection, hover } = state;
 
   const emitter = createNanoEvents<RendererEvents>();
 
-  let currentStyle: HighlightStyleExpression | undefined;
+  let currentStyle: HighlightStyleExpression<I> | undefined;
 
-  const styleOverrides = new Map<string, HighlightStyleExpression>();
+  const styleOverrides = new Map<string, HighlightStyleExpression<I>>();
 
   let currentFilter: Filter | undefined;
 
@@ -139,7 +139,7 @@ export const createRenderer = <T extends TextAnnotatorState = TextAnnotatorState
     }, 1);
   }), 10);
 
-  const setStyle = (style?: HighlightStyleExpression, id?: string) => {
+  const setStyle = (style?: HighlightStyleExpression<I>, id?: string) => {
     if (id) {
       if (style)
         styleOverrides.set(id, style);

--- a/packages/text-annotator/src/rendering/base-renderer.ts
+++ b/packages/text-annotator/src/rendering/base-renderer.ts
@@ -1,6 +1,6 @@
 import { createNanoEvents, type Unsubscribe } from 'nanoevents';
 import { UserSelectAction, type Annotation, type AnnotatorState, type Filter, type ViewportState } from '@annotorious/core';
-import type { TextAnnotation } from '../model';
+import type { TextAnnotation, TextAnnotationLike } from '../model';
 import type { TextAnnotatorState } from '../state';
 import { 
   type Highlight,
@@ -17,7 +17,7 @@ import { debounce } from '../utils/events';
 /**
  * The renderer runtime interface.
  */
-export interface Renderer<I extends TextAnnotation = TextAnnotation> {
+export interface Renderer<I extends TextAnnotationLike = TextAnnotation> {
 
   destroy(): void;
 
@@ -39,7 +39,7 @@ export interface RendererEvents {
 
 }
 
-export type RendererFactory<T extends Annotation> = (
+export type RendererFactory<T extends TextAnnotationLike> = (
 
   container: HTMLElement,
 
@@ -47,14 +47,14 @@ export type RendererFactory<T extends Annotation> = (
 
   viewport: ViewportState
 
-) => Renderer;
+) => Renderer<T>;
 
 /**
  * A utility interface. Instead of implementing a Renderer from scratch,
  * implementers can simply implement a painter, and wrap it in the
  * BaseRenderer, which will handle common concerns.
  */
-export interface Painter<I extends TextAnnotation = TextAnnotation> {
+export interface Painter<I extends TextAnnotationLike = TextAnnotation> {
 
   destroy(): void;
 
@@ -70,7 +70,7 @@ export interface Painter<I extends TextAnnotation = TextAnnotation> {
 
 }
 
-export const createRenderer = <T extends TextAnnotatorState = TextAnnotatorState<TextAnnotation, any>, I extends TextAnnotation = TextAnnotation>(
+export const createRenderer = <T extends TextAnnotatorState = TextAnnotatorState<TextAnnotation, any>, I extends TextAnnotationLike = TextAnnotation>(
   painter: Painter<I>,
   container: HTMLElement,
   state: T,

--- a/packages/text-annotator/src/rendering/highlight-style.ts
+++ b/packages/text-annotator/src/rendering/highlight-style.ts
@@ -1,6 +1,6 @@
 import { colord, type AnyColor } from 'colord';
 import type { AnnotationState, Color, DrawingStyle } from '@annotorious/core';
-import type { TextAnnotation } from '../model';
+import type { TextAnnotation, TextAnnotationLike } from '../model';
 import type { Highlight } from './';
 
 export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity'> {
@@ -15,7 +15,7 @@ export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity
   
 }
 
-export type HighlightStyleExpression<I extends TextAnnotation = TextAnnotation> = HighlightStyle
+export type HighlightStyleExpression<I extends TextAnnotationLike = TextAnnotation> = HighlightStyle
   | ((annotation: I, state: AnnotationState, zIndex?: number) => HighlightStyle | undefined);
 
 export const DEFAULT_STYLE: HighlightStyle = { 

--- a/packages/text-annotator/src/rendering/highlight-style.ts
+++ b/packages/text-annotator/src/rendering/highlight-style.ts
@@ -15,8 +15,8 @@ export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity
   
 }
 
-export type HighlightStyleExpression = HighlightStyle 
-  | (<I extends TextAnnotation = TextAnnotation>(annotation: I, state: AnnotationState, zIndex?: number) => HighlightStyle | undefined);
+export type HighlightStyleExpression<I extends TextAnnotation = TextAnnotation> = HighlightStyle
+  | ((annotation: I, state: AnnotationState, zIndex?: number) => HighlightStyle | undefined);
 
 export const DEFAULT_STYLE: HighlightStyle = { 
   fill: 'rgb(0, 128, 255)', 

--- a/packages/text-annotator/src/text-annotator-options.ts
+++ b/packages/text-annotator/src/text-annotator-options.ts
@@ -37,7 +37,7 @@ export interface TextAnnotatorOptions<I extends TextAnnotationLike = TextAnnotat
 
   selectionMode?: 'shortest' | 'all';
 
-  style?: HighlightStyleExpression;
+  style?: HighlightStyleExpression<I>;
 
   user?: User;
 

--- a/packages/text-annotator/src/text-annotator.ts
+++ b/packages/text-annotator/src/text-annotator.ts
@@ -38,9 +38,9 @@ export interface TextAnnotator<I extends TextAnnotationLike = TextAnnotation, E 
 
   element: HTMLElement;
 
-  renderer: Renderer;
+  renderer: Renderer<I>;
 
-  setStyle(style?: HighlightStyleExpression, id?: string): void;
+  setStyle(style?: HighlightStyleExpression<I>, id?: string): void;
 
   // Returns true if successful (or false if the annotation is not currently rendered)
   scrollIntoView(annotationOrId: I | string, scrollParentOrId?: string | Element): boolean;

--- a/packages/text-annotator/src/text-annotator.ts
+++ b/packages/text-annotator/src/text-annotator.ts
@@ -96,7 +96,7 @@ export const createTextAnnotator = <I extends TextAnnotationLike = TextAnnotatio
     null;
 
   // Likewise: not an ideal cast...
-  const renderer =
+  const renderer = (
     useBuiltInRenderer === null ? (opts.renderer as RendererFactory<I>)(
       container, 
       state as unknown as AnnotatorState<I, E>, 
@@ -109,7 +109,8 @@ export const createTextAnnotator = <I extends TextAnnotationLike = TextAnnotatio
       container, 
       state as unknown as AnnotatorState<TextAnnotation, E>, 
       viewport) :
-    undefined;
+    undefined
+  ) as unknown as Renderer<I> | undefined;
 
   if (!renderer)
     throw `Unknown renderer implementation: ${opts.renderer}`;


### PR DESCRIPTION
## Issue
`HighlightStyleExpression` was declared as a non-generic type alias where the `I` type parameter was scoped to the function overload inside the union, not to the type alias itself. This made it impossible for consuming apps to parameterize it with a custom annotation type. The obvious workaround:
```ts
type HighlightStyleFn = Extract<HighlightStyleExpression, Function>;
const style: HighlightStyleFn<WebtextsAnnotation> = ...
// TS2315: Type 'HighlightStyleFn' is not generic.
```
fails because `Extract` produces a non-generic function type, the inner `<I>` is erased.

Additionally, even though `TextAnnotatorOptions<I>` and `TextAnnotator<I>` carried a concrete annotation type parameter, style and `setStyle` were still typed as the unparameterized `HighlightStyleExpression`, so the narrow annotation type was never forwarded to styling callbacks.

## Changes Made
`HighlightStyleExpression` is now a proper generic type alias: `HighlightStyleExpression<I extends TextAnnotation = TextAnnotation>`,  with `TextAnnotation` as the default, so existing usages remain unchanged.

The concrete annotation type is now forwarded from `TextAnnotatorOptions<I>` and `TextAnnotator<I>` down to their `style` / `setStyle` members, and through the renderer and painter interfaces. 

`PDFAnnotator` and its React wrapper are similarly updated to use `PDFAnnotation` as the concrete type.


###### Soomo Staged 21.05.26