### PR TITLE
Fixed trimming ranges that are entirely outside the annotatable container

### DIFF
--- a/packages/text-annotator/src/selection-handler.ts
+++ b/packages/text-annotator/src/selection-handler.ts
@@ -10,7 +10,7 @@ import type { AnnotatingMode } from './text-annotator';
 import type { TextAnnotatorOptions } from './text-annotator-options';
 import { rangeToSelector } from './utils/annotation';
 import { clonePointerEvent, cloneKeyboardEvent } from './utils/events';
-import { 
+import {
   isMac,
   isNotAnnotatable,
   isRangeAnnotatable,
@@ -155,9 +155,11 @@ export const createSelectionHandler = <T extends TextAnnotation>(
     const selectionRanges =
       Array.from(Array(sel.rangeCount).keys()).map(idx => sel.getRangeAt(idx));
 
+    // Drop any range that doesn't intersect the annotatable container at all before we attempt to trim it
+    const intersectingRanges = selectionRanges.filter(r => r.intersectsNode(container));
+
     // The selection should be captured only within the annotatable container
-    const containedRanges =
-      selectionRanges.map(r => trimRangeToContainer(r, container));
+    const containedRanges = intersectingRanges.map(r => trimRangeToContainer(r, container));
 
     /**
      * This is to handle cases where the selection is "hijacked" by


### PR DESCRIPTION
## Issue
Fixes https://github.com/recogito/text-annotator-js/issues/267

Resolves a regression introduced by the https://github.com/recogito/text-annotator-js/pull/264

---

`trimRangeToContainer` clamps a range's
endpoints to the container's bounds whenever they fall outside of it - so a selection made entirely outside the container would otherwise be "rescued" into a phantom range spanning the container's full content.

https://github.com/user-attachments/assets/73edeacc-0d0e-4a61-b445-1937cb46fc1d