### PR TITLE
Type Model Refactoring

### DIFF
--- a/packages/pdf-annotator/src/pdf-annotator.ts
+++ b/packages/pdf-annotator/src/pdf-annotator.ts
@@ -2,7 +2,9 @@ import { createSelectionHandler, createSpansRenderer, fillDefaults } from '@reco
 import type { 
   AnnotatingMode, 
   HighlightStyleExpression, 
+  RevivedTextAnnotationLike, 
   TextAnnotation, 
+  TextAnnotationLike, 
   TextAnnotator, 
   TextAnnotatorOptions, 
   TextAnnotatorState
@@ -64,7 +66,7 @@ export const createPDFAnnotator = (
 
   const renderer = createSpansRenderer(
     viewerElement, 
-    state as unknown as TextAnnotatorState<TextAnnotation, PDFAnnotation>, 
+    state as unknown as TextAnnotatorState<TextAnnotationLike, PDFAnnotation>, 
     viewport);
 
   if (opts.style)
@@ -72,8 +74,8 @@ export const createPDFAnnotator = (
 
   const selectionHandler = createSelectionHandler(
     container.querySelector('.pdfViewer')!, 
-    state as unknown as TextAnnotatorState<TextAnnotation, PDFAnnotation>, 
-    lifecycle as Lifecycle<TextAnnotation, PDFAnnotation>,
+    state as unknown as TextAnnotatorState<RevivedTextAnnotationLike, PDFAnnotation>, 
+    lifecycle as Lifecycle<TextAnnotationLike, PDFAnnotation>,
     // @ts-ignore
     { ...opts, offsetReferenceSelector: '.page' }
   );

--- a/packages/pdf-annotator/src/state/pdf-annotator-state.ts
+++ b/packages/pdf-annotator/src/state/pdf-annotator-state.ts
@@ -2,6 +2,9 @@ import * as pdfjsViewer from 'pdfjs-dist/legacy/web/pdf_viewer.mjs';
 import { createTextAnnotatorState, Origin } from '@recogito/text-annotator';
 import type { 
   HoverState, 
+  RevivedTextAnnotationLike, 
+  RevivedTextAnnotationTargetLike, 
+  RevivedTextSelector, 
   SelectionState, 
   TextAnnotation, 
   TextAnnotationStore, 
@@ -71,10 +74,10 @@ export const createPDFAnnotatorState = (
     });
   }
 
-  const toPDFAnnotationTarget = (target: TextAnnotationTarget) => {    
+  const toPDFAnnotationTarget = (target: RevivedTextAnnotationTargetLike<TextAnnotationTarget>) => {    
     // Split the text annotation target across pages, if necessary.
-    const split = target.selector.reduce<TextSelector[]>((all, selector) => (
-      [...all, ...splitSelector(target.selector[0])]
+    const split = target.selector.reduce<RevivedTextSelector[]>((all, selector) => (
+      [...all, ...splitSelector(selector as RevivedTextSelector)]
     ), []);
 
     // CAUTION: some annotations seem to be re-split. Investigate! 
@@ -85,7 +88,7 @@ export const createPDFAnnotatorState = (
     // Container element bounds
     const offset = viewerElement.getBoundingClientRect().top;
 
-    const getRectsForSelector = (selector: TextSelector) => {
+    const getRectsForSelector = (selector: RevivedTextSelector) => {
       const bounds = selector.range.getBoundingClientRect();
 
       // Checking for vertical intersection is enough, because we know
@@ -95,7 +98,7 @@ export const createPDFAnnotatorState = (
       ));
     }
 
-    const toPDFSelector = (s: TextSelector) => {
+    const toPDFSelector = (s: RevivedTextSelector) => {
       const pageNumber = parseInt(s.offsetReference?.dataset.pageNumber!);
       return {
         ...s,
@@ -110,7 +113,7 @@ export const createPDFAnnotatorState = (
     } as PDFAnnotationTarget;
   }
 
-  const toPDFAnnotation = (t: TextAnnotation) => ({
+  const toPDFAnnotation = (t: RevivedTextAnnotationLike<TextAnnotation>) => ({
     ...t,
     target: toPDFAnnotationTarget(t.target)
   });
@@ -174,7 +177,8 @@ export const createPDFAnnotatorState = (
     const { changes } = event;
 
     // Annotations coming from the innerStore or all TextAnnotations!
-    const created: PDFAnnotation[] = (changes.created || []).map(toPDFAnnotation);
+    const created: PDFAnnotation[] = (changes.created || []).map(a => 
+      toPDFAnnotation(a as unknown as RevivedTextAnnotationLike<TextAnnotation>));
 
     // Update the store silently, i.e. without triggering events
     // @ts-ignore
@@ -182,7 +186,7 @@ export const createPDFAnnotatorState = (
 
     const updated = (changes.updated || []).map(e => {
       if (e.targetUpdated) {
-        const newTarget = toPDFAnnotationTarget(e.targetUpdated.newTarget as TextAnnotationTarget);
+        const newTarget = toPDFAnnotationTarget(e.targetUpdated.newTarget as unknown as RevivedTextAnnotationTargetLike<TextAnnotationTarget>);
         const oldValue: PDFAnnotation = e.oldValue as PDFAnnotation;
 
         const newValue: PDFAnnotation = {
@@ -205,10 +209,11 @@ export const createPDFAnnotatorState = (
     });
 
     // Update silently
-    // @ts-ignore
     updated.forEach(u => innerStore.updateAnnotation(u.newValue, Origin.SILENT));
 
-    const deleted: PDFAnnotation[] = (changes.deleted || []).map(toPDFAnnotation);
+    const deleted: PDFAnnotation[] = (changes.deleted || []).map(a => 
+      toPDFAnnotation(a as unknown as RevivedTextAnnotationLike<TextAnnotation>));
+
     deleted.forEach(a => renderedAnnotations.deleteAnnotation(a));
 
     const crosswalked = {

--- a/packages/pdf-annotator/src/utils/annotation/revive-annotation.ts
+++ b/packages/pdf-annotator/src/utils/annotation/revive-annotation.ts
@@ -27,8 +27,7 @@ export const reviveSelector = (selector: PDFSelector | TextSelector): PDFSelecto
       return selector as PDFSelector;
     } else {
       // No pageNumber, but offsetReference element -> crosswalk
-      const { offsetReference } = selector as unknown as RevivedTextSelectorLike;
-      const pageNumber = parseInt(offsetReference!.dataset.pageNumber!);
+      const pageNumber = parseInt(selector.offsetReference!.dataset.pageNumber!);
     
       // @ts-ignore
       return {

--- a/packages/pdf-annotator/src/utils/annotation/revive-annotation.ts
+++ b/packages/pdf-annotator/src/utils/annotation/revive-annotation.ts
@@ -1,4 +1,4 @@
-import type { TextAnnotation, TextAnnotationTarget, TextSelector } from '@recogito/text-annotator';
+import type { RevivedTextSelectorLike, TextAnnotation, TextAnnotationTarget, TextSelector } from '@recogito/text-annotator';
 import type { PDFAnnotation, PDFAnnotationTarget, PDFSelector } from '../../model/core/pdf-annotation';
 
 /**
@@ -27,7 +27,7 @@ export const reviveSelector = (selector: PDFSelector | TextSelector): PDFSelecto
       return selector as PDFSelector;
     } else {
       // No pageNumber, but offsetReference element -> crosswalk
-      const { offsetReference } = selector;
+      const { offsetReference } = selector as unknown as RevivedTextSelectorLike;
       const pageNumber = parseInt(offsetReference!.dataset.pageNumber!);
     
       // @ts-ignore

--- a/packages/pdf-annotator/src/utils/dom/split-selector.ts
+++ b/packages/pdf-annotator/src/utils/dom/split-selector.ts
@@ -1,12 +1,12 @@
-import type { TextSelector } from '@recogito/text-annotator';
+import type { RevivedTextSelector, TextSelector } from '@recogito/text-annotator';
 
-export const isSamePage = (selector: TextSelector) => {
+export const isSamePage = (selector: RevivedTextSelector) => {
   const startPage = selector.range.startContainer.parentElement?.closest('.page');
   const endPage = selector.range.endContainer.parentElement?.closest('.page');
   return startPage === endPage;
 }
 
-const pageRangeToTextSelectorSelector = (range: Range): TextSelector => {
+const pageRangeToTextSelectorSelector = (range: Range): RevivedTextSelector => {
   const rangeBefore = document.createRange();
 
   const offsetReference: HTMLElement = range.startContainer instanceof HTMLElement 
@@ -31,7 +31,7 @@ const pageRangeToTextSelectorSelector = (range: Range): TextSelector => {
 
 }
 
-export const splitSelector = (selector: TextSelector): TextSelector[] => {
+export const splitSelector = (selector: RevivedTextSelector): RevivedTextSelector[] => {
   const startPage = selector.range.startContainer.parentElement!.closest('.page')!;
   const endPage = selector.range.endContainer.parentElement!.closest('.page')!;
 

--- a/packages/pdf-annotator/src/utils/dom/split-selector.ts
+++ b/packages/pdf-annotator/src/utils/dom/split-selector.ts
@@ -1,4 +1,4 @@
-import type { RevivedTextSelector, TextSelector } from '@recogito/text-annotator';
+import type { RevivedTextSelector } from '@recogito/text-annotator';
 
 export const isSamePage = (selector: RevivedTextSelector) => {
   const startPage = selector.range.startContainer.parentElement?.closest('.page');

--- a/packages/pdf-annotator/test/index.html
+++ b/packages/pdf-annotator/test/index.html
@@ -98,7 +98,7 @@
         anno.on('deleteAnnotation', a => console.log('delete', a));
         anno.on('updateAnnotation', (a, b) => console.log('update', a));
 
-        //  anno.loadAnnotations('annotations.json');
+        anno.loadAnnotations('annotations.json');
 
         document.getElementById('size-auto')
           .addEventListener('click', () => anno.setSize('auto'));

--- a/packages/text-annotator-react/src/index.ts
+++ b/packages/text-annotator-react/src/index.ts
@@ -11,7 +11,6 @@ export type {
   AnnotationTarget,
   Annotator,
   AnnotatorState,
-  Color,
   Filter,
   FormatAdapter,
   HoverState,

--- a/packages/text-annotator-tei/src/crosswalk/forward.ts
+++ b/packages/text-annotator-tei/src/crosswalk/forward.ts
@@ -1,9 +1,14 @@
-import type { TEIAnnotation, TEIAnnotationTarget, TEIRangeSelector } from '../tei-annotation';
+import type { RevivedTEIAnnotationTarget, RevivedTEIRangeSelector, TEIAnnotation, TEIAnnotationTarget, TEIRangeSelector } from '../tei-annotation';
 import { reanchor } from './utils';
-import type { 
-  TextAnnotation, 
-  TextAnnotationTarget, 
-  TextSelector
+import { 
+  isRevived,
+  type RevivedTextAnnotationLike,
+  type RevivedTextAnnotationTargetLike,
+  type RevivedTextSelector,
+  type RevivedTextSelectorLike,
+  type TextAnnotation, 
+  type TextAnnotationTarget,
+  type TextSelector
 } from '@recogito/text-annotator';
 
 const elementCache = new Map<string, Node>();
@@ -185,7 +190,7 @@ const parseXPathExpression = (expression: string) => {
  * the TEIRangeSelector corresponding to that range. We need this because
  * the Text Annotator will always produce a TextAnnotation natively.
  */
-export const textToTEISelector = (container: HTMLElement) => (selector: TextSelector): TEIRangeSelector & TextSelector => {
+export const textToTEISelector = (container: HTMLElement) => (selector: RevivedTextSelector): RevivedTEIRangeSelector & RevivedTextSelector => {
   const { start, end, range } = selector;
 
   // XPath segments for Range start and end nodes as a list
@@ -220,9 +225,9 @@ export const textToTEISelector = (container: HTMLElement) => (selector: TextSele
   };
 }
 
-export const reviveSelector = (selector: TEIRangeSelector, container: HTMLElement): TEIRangeSelector => {
+export const reviveSelector = (selector: TEIRangeSelector, container: HTMLElement): RevivedTEIRangeSelector => {
   // Don't revive unncessarily
-  if (selector.position && selector.range instanceof Range) return selector;
+  if (selector.position && isRevived(selector)) return selector;
 
   const startExpression = selector.startSelector?.value;
   const endExpression = selector.endSelector?.value;
@@ -280,14 +285,14 @@ export const reviveTarget = (t: TEIAnnotationTarget, container: HTMLElement) => 
   selector: t.selector.map(s => reviveSelector(s, container))
 });
 
-export const textToTEITarget =  (container: HTMLElement) => (target: TextAnnotationTarget | TEIAnnotationTarget): TEIAnnotationTarget => {
+export const textToTEITarget =  (container: HTMLElement) => (target: TEIAnnotationTarget | RevivedTextAnnotationTargetLike<TextAnnotationTarget>): RevivedTEIAnnotationTarget => {
   return {
     ...target,
-    selector: target.selector.map(s => 'startSelector' in s ? reviveSelector(s, container) : textToTEISelector(container)(s))
+    selector: target.selector.map(s => 'startSelector' in s ? reviveSelector(s, container) : textToTEISelector(container)(s as RevivedTextSelector))
   }
 }
 
-export const textToTEIAnnotation = (container: HTMLElement) => (a: TextAnnotation | TEIAnnotation): TEIAnnotation => ({
+export const textToTEIAnnotation = (container: HTMLElement) => (a: RevivedTextAnnotationLike<TextAnnotation> | TEIAnnotation): TEIAnnotation => ({
   ...a,
   target: textToTEITarget(container)(a.target)
 })

--- a/packages/text-annotator-tei/src/tei-annotation.ts
+++ b/packages/text-annotator-tei/src/tei-annotation.ts
@@ -1,4 +1,9 @@
-import type { TextAnnotationLike, TextAnnotationTargetLike, TextSelectorLike } from '@recogito/text-annotator';
+import type { 
+  RevivedTextSelectorLike, 
+  TextAnnotationLike, 
+  TextAnnotationTargetLike, 
+  TextSelectorLike 
+} from '@recogito/text-annotator';
 
 export interface TEIAnnotation extends TextAnnotationLike {
 
@@ -33,3 +38,17 @@ export interface TEIRangeSelector extends TextSelectorLike {
   }
 
 }
+
+export interface RevivedTEIAnnotationTarget extends TEIAnnotationTarget {
+
+  selector: RevivedTEIRangeSelector[];
+
+}
+
+export interface RevivedTEIAnnotation extends TEIAnnotation {
+
+  target: RevivedTEIAnnotationTarget;
+
+}
+
+export type RevivedTEIRangeSelector = TEIRangeSelector & RevivedTextSelectorLike;

--- a/packages/text-annotator-tei/src/tei-annotator.ts
+++ b/packages/text-annotator-tei/src/tei-annotator.ts
@@ -1,4 +1,6 @@
 import { 
+  type RevivedTextAnnotationLike,
+  type RevivedTextAnnotationTargetLike,
   type TextAnnotation,
   type TextAnnotationTarget,
   type TextAnnotatorOptions,
@@ -52,7 +54,7 @@ export const createTEIAnnotator = <T extends unknown>(
     const { selector } = annotation.target;
     try {
       return (!('startSelector' in selector)) ?
-        _addAnnotation(toTEI(annotation as TextAnnotation), origin) :
+        _addAnnotation(toTEI(annotation as RevivedTextAnnotationLike<TextAnnotation>), origin) :
         _addAnnotation(annotation as TEIAnnotation, origin);
     } catch (error) {
       console.warn(error);
@@ -65,7 +67,7 @@ export const createTEIAnnotator = <T extends unknown>(
   store.bulkAddAnnotations = (annotations: Array<TEIAnnotation | TextAnnotation>, replace = true, origin: Origin) => {
     const teiAnnotations = annotations.map(a => {
       try {
-        return toTEI(a);
+        return toTEI(a as TEIAnnotation);
       } catch (error) {
         console.warn(error);
       }
@@ -84,12 +86,13 @@ export const createTEIAnnotator = <T extends unknown>(
   }
 
   const _updateAnnotation = store.updateAnnotation;
+  
   // @ts-ignore
-  store.updateAnnotation = (annotation: TEIAnnotation | TextAnnotation, origin: Origin) =>
+  store.updateAnnotation = (annotation: TEIAnnotation | RevivedTextAnnotationLike<TextAnnotation>, origin: Origin) =>
     _updateAnnotation(toTEI(annotation), origin);
 
   const _updateTarget = store.updateTarget;
-  store.updateTarget = (target: TEIAnnotationTarget | TextAnnotationTarget, origin: Origin = Origin.LOCAL) => 
+  store.updateTarget = (target: TEIAnnotationTarget | RevivedTextAnnotationTargetLike<TextAnnotationTarget>, origin: Origin = Origin.LOCAL) => 
     _updateTarget(toTEITarget(target), origin);
 
   return {

--- a/packages/text-annotator/src/index.ts
+++ b/packages/text-annotator/src/index.ts
@@ -16,7 +16,6 @@ export type {
   AnnotationTarget,
   Annotator,
   AnnotatorState,
-  Color,
   Filter,
   FormatAdapter,
   HoverState,

--- a/packages/text-annotator/src/model/core/text-annotation.ts
+++ b/packages/text-annotator/src/model/core/text-annotation.ts
@@ -1,32 +1,15 @@
 import type { Annotation, AnnotationTarget } from '@annotorious/core';
 
-export interface TextAnnotation extends Annotation {
-
-  target: TextAnnotationTarget;
-
-}
-
-export interface TextAnnotationTarget extends AnnotationTarget {
-
-  selector: TextSelector[];
-
-}
-
-export interface TextSelector {
-
-  id?: string;
-
-  quote: string;
-  
-  start: number;
-
-  end: number;
-
-  range: Range;
-
-  offsetReference?: HTMLElement;
-
-}
+/**
+ * The Text Annotator model is becoming slightly complex. But it seems
+ * justified since we need to dealing with two orthogonal issues:
+ * 
+ * - Annotations come in "revived" and "unrevived" states (with or without 
+ *   resolved DOM elements: Range and offset element)
+ * - Annotations can be "plain" HTML/text annotations with `start` and `end`
+ *   character offset fields, or annotations from extensions (TEI/XML, PDF)
+ *   which handle the serializable anchoring differently (XPath, pages)
+ */
 
 export interface TextAnnotationLike extends Annotation {
 
@@ -46,8 +29,71 @@ export interface TextSelectorLike {
 
   quote: string;
 
+}
+
+export interface RevivedTextSelectorLike extends TextSelectorLike {
+
   range: Range;
 
   offsetReference?: HTMLElement;
 
+}
+
+/**
+ * Core classes - this is what most parts of the core deal with:
+ * a TextAnnotationLike with all-revived selectors
+ */
+export type RevivedTextAnnotationLike<T extends TextAnnotationLike = TextAnnotationLike> = T & {
+
+  target: RevivedTextAnnotationTargetLike;
+
+}
+
+export type RevivedTextAnnotationTargetLike<T extends TextAnnotationTargetLike = TextAnnotationTargetLike> = Omit<T, 'selector'> & {
+
+  selector: RevivedTextSelectorLike[];
+
+}
+
+/**
+ * Default specialization of TextAnnotationLike
+ */
+export interface TextAnnotation extends TextAnnotationLike {
+
+  target: TextAnnotationTarget;
+
+}
+
+export interface TextAnnotationTarget extends TextAnnotationTargetLike {
+
+  selector: TextSelector[];
+
+}
+
+export interface TextSelector extends TextSelectorLike {
+  
+  start: number;
+
+  end: number;
+
+}
+
+export type RevivedTextSelector = TextSelector & RevivedTextSelectorLike;
+
+/**
+ * Utility type guards
+ */
+export const isRevivedAnnotation = (annotation: TextAnnotationLike): annotation is RevivedTextAnnotationLike => 
+  annotation.target.selector.every(isRevived);
+
+export const isRevivedTarget = (target: TextAnnotationTargetLike): target is TextAnnotationTargetLike & {
+  selector: RevivedTextSelectorLike[]
+} => target.selector.every(isRevived);
+
+export function isRevived(selector: TextSelectorLike): selector is RevivedTextSelectorLike;
+export function isRevived(selectors: TextSelectorLike[]): selectors is RevivedTextSelectorLike[];
+export function isRevived(selector: TextSelectorLike | TextSelectorLike[]): boolean {
+  return Array.isArray(selector)
+    ? selector.every(s => 'range' in s && s.range instanceof Range && !s.range.collapsed)
+    : 'range' in selector && selector.range instanceof Range && !selector.range.collapsed;
 }

--- a/packages/text-annotator/src/model/core/text-annotation.ts
+++ b/packages/text-annotator/src/model/core/text-annotation.ts
@@ -45,7 +45,7 @@ export interface RevivedTextSelectorLike extends TextSelectorLike {
  */
 export type RevivedTextAnnotationLike<T extends TextAnnotationLike = TextAnnotationLike> = T & {
 
-  target: RevivedTextAnnotationTargetLike;
+  target: RevivedTextAnnotationTargetLike<T['target']>;
 
 }
 

--- a/packages/text-annotator/src/model/core/text-annotation.ts
+++ b/packages/text-annotator/src/model/core/text-annotation.ts
@@ -29,13 +29,13 @@ export interface TextSelectorLike {
 
   quote: string;
 
+  offsetReference?: HTMLElement;
+
 }
 
 export interface RevivedTextSelectorLike extends TextSelectorLike {
 
   range: Range;
-
-  offsetReference?: HTMLElement;
 
 }
 

--- a/packages/text-annotator/src/model/core/text-annotation.ts
+++ b/packages/text-annotator/src/model/core/text-annotation.ts
@@ -86,9 +86,7 @@ export type RevivedTextSelector = TextSelector & RevivedTextSelectorLike;
 export const isRevivedAnnotation = (annotation: TextAnnotationLike): annotation is RevivedTextAnnotationLike => 
   annotation.target.selector.every(isRevived);
 
-export const isRevivedTarget = (target: TextAnnotationTargetLike): target is TextAnnotationTargetLike & {
-  selector: RevivedTextSelectorLike[]
-} => target.selector.every(isRevived);
+export const isRevivedTarget = (target: TextAnnotationTargetLike): target is RevivedTextAnnotationTargetLike => target.selector.every(isRevived);
 
 export function isRevived(selector: TextSelectorLike): selector is RevivedTextSelectorLike;
 export function isRevived(selectors: TextSelectorLike[]): selectors is RevivedTextSelectorLike[];

--- a/packages/text-annotator/src/model/w3c/w3c-text-format-adapter.ts
+++ b/packages/text-annotator/src/model/w3c/w3c-text-format-adapter.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
-import type { TextAnnotation, TextAnnotationTarget, TextSelector } from '../core';
+import { isRevived } from '../core';
+import type { TextAnnotationLike, TextAnnotationTarget, TextSelector } from '../core';
 import type { W3CTextAnnotation, W3CTextAnnotationTarget, W3CTextSelector } from './';
 import { getQuoteContext } from '../../utils/annotation';
 import {
@@ -10,14 +11,14 @@ import {
   serializeW3CBodies
 } from '@annotorious/core';
 
-export type W3CTextFormatAdapter<I extends TextAnnotation = TextAnnotation, E extends W3CTextAnnotation = W3CTextAnnotation> = FormatAdapter<I, E>;
+export type W3CTextFormatAdapter<I extends TextAnnotationLike = TextAnnotationLike, E extends W3CTextAnnotation = W3CTextAnnotation> = FormatAdapter<I, E>;
 
 /**
  * @param source - the IRI of the annotated content
  * @param container - the HTML container of the annotated content,
  *                    Required to locate the content's `range` within the DOM
  */
-export const W3CTextFormat =<I extends TextAnnotation = TextAnnotation, E extends W3CTextAnnotation = W3CTextAnnotation>(
+export const W3CTextFormat =<I extends TextAnnotationLike = TextAnnotationLike, E extends W3CTextAnnotation = W3CTextAnnotation>(
   source: string,
   container?: HTMLElement
 ): W3CTextFormatAdapter<I, E> => ({
@@ -90,7 +91,7 @@ const parseW3CTextTargets = (annotation: W3CTextAnnotation) => {
   return { parsed };
 };
 
-export const parseW3CTextAnnotation = <I extends TextAnnotation = TextAnnotation, E extends W3CTextAnnotation = W3CTextAnnotation>(
+export const parseW3CTextAnnotation = <I extends TextAnnotationLike = TextAnnotationLike, E extends W3CTextAnnotation = W3CTextAnnotation>(
   annotation: E
 ): ParseResult<I> => {
   const annotationId = annotation.id || uuidv4();
@@ -121,7 +122,7 @@ export const parseW3CTextAnnotation = <I extends TextAnnotation = TextAnnotation
 
 };
 
-export const serializeW3CTextAnnotation = <I extends TextAnnotation = TextAnnotation, E extends W3CTextAnnotation = W3CTextAnnotation>(
+export const serializeW3CTextAnnotation = <I extends TextAnnotationLike = TextAnnotationLike, E extends W3CTextAnnotation = W3CTextAnnotation>(
   annotation: I,
   source: string,
   container?: HTMLElement
@@ -137,19 +138,24 @@ export const serializeW3CTextAnnotation = <I extends TextAnnotation = TextAnnota
   } = target;
 
   const w3cTargets = selector.map((s): W3CTextAnnotationTarget => {
-    const { id, quote, start, end, range } = s;
+    const { id, quote } = s;
 
     const quoteSelector: W3CTextSelector = {
       type: 'TextQuoteSelector',
       exact: quote
     }
 
-    if (container) {
-      const { prefix, suffix } = getQuoteContext(range, container);
+    if (container && isRevived(s)) {
+      const { prefix, suffix } = getQuoteContext(s.range, container);
       quoteSelector.prefix = prefix;
       quoteSelector.suffix = suffix;
     }
 
+    if (!('start' in s)) 
+      throw new Error('W3C serialization requires TextSelector with start/end');
+
+    const { start, end } = s as TextSelector;
+    
     const positionSelector: W3CTextSelector = {
       type: 'TextPositionSelector',
       start,

--- a/packages/text-annotator/src/model/w3c/w3c-text-format-adapter.ts
+++ b/packages/text-annotator/src/model/w3c/w3c-text-format-adapter.ts
@@ -1,5 +1,4 @@
 import { v4 as uuidv4 } from 'uuid';
-import { isRevived } from '../core';
 import type { TextAnnotationLike, TextAnnotationTarget, TextSelector } from '../core';
 import type { W3CTextAnnotation, W3CTextAnnotationTarget, W3CTextSelector } from './';
 import { getQuoteContext } from '../../utils/annotation';

--- a/packages/text-annotator/src/model/w3c/w3c-text-format-adapter.ts
+++ b/packages/text-annotator/src/model/w3c/w3c-text-format-adapter.ts
@@ -145,8 +145,9 @@ export const serializeW3CTextAnnotation = <I extends TextAnnotationLike = TextAn
       exact: quote
     }
 
-    if (container && isRevived(s)) {
-      const { prefix, suffix } = getQuoteContext(s.range, container);
+    // Doesn't pass the isRevived test in test mode
+    if (container && 'range' in s) {
+      const { prefix, suffix } = getQuoteContext(s.range as Range, container);
       quoteSelector.prefix = prefix;
       quoteSelector.suffix = suffix;
     }

--- a/packages/text-annotator/src/rendering/highlight-style.ts
+++ b/packages/text-annotator/src/rendering/highlight-style.ts
@@ -1,18 +1,24 @@
 import { colord, type AnyColor } from 'colord';
-import type { AnnotationState, Color, DrawingStyle } from '@annotorious/core';
+import type { AnnotationState } from '@annotorious/core';
 import type { TextAnnotationLike } from '../model';
 import type { Highlight } from './';
 
-export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity'> {
+export type CSSColor = string;
+
+export interface HighlightStyle {
+
+  fill?: CSSColor;
+
+  fillOpacity?: number;
 
   underlineStyle?: string;
 
-  underlineColor?: Color;
+  underlineColor?: CSSColor;
 
   underlineOffset?: number;
 
   underlineThickness?: number;
-  
+
 }
 
 export type HighlightStyleExpression = HighlightStyle 

--- a/packages/text-annotator/src/rendering/highlight.ts
+++ b/packages/text-annotator/src/rendering/highlight.ts
@@ -1,8 +1,8 @@
 import type { AnnotationState } from '@annotorious/core';
-import type { TextAnnotationLike } from '../model';
+import type { RevivedTextAnnotationLike } from '../model';
 import type { AnnotationRects } from '../state';
 
-export interface Highlight extends AnnotationRects<TextAnnotationLike> {
+export interface Highlight extends AnnotationRects<RevivedTextAnnotationLike> {
 
   state: AnnotationState;
 

--- a/packages/text-annotator/src/rendering/renderer-css-highlight/css-highlight-renderer.ts
+++ b/packages/text-annotator/src/rendering/renderer-css-highlight/css-highlight-renderer.ts
@@ -1,6 +1,6 @@
 import type { ViewportState } from '@annotorious/core';
 import { colord, type AnyColor } from 'colord';
-import type { RevivedTextAnnotationLike, RevivedTextSelectorLike, TextAnnotationLike } from '../../model';
+import type { RevivedTextSelectorLike, TextAnnotationLike } from '../../model';
 import type { TextAnnotatorState } from '../../state';
 import { 
   computeStyle,

--- a/packages/text-annotator/src/rendering/renderer-css-highlight/css-highlight-renderer.ts
+++ b/packages/text-annotator/src/rendering/renderer-css-highlight/css-highlight-renderer.ts
@@ -1,6 +1,6 @@
 import type { ViewportState } from '@annotorious/core';
 import { colord, type AnyColor } from 'colord';
-import type { TextAnnotation } from '../../model';
+import type { RevivedTextAnnotationLike, RevivedTextSelectorLike, TextAnnotationLike } from '../../model';
 import type { TextAnnotatorState } from '../../state';
 import { 
   computeStyle,
@@ -41,11 +41,11 @@ export const createCSSHighlightPainter = (): Painter => {
   let currentRendered = new Set<string>();
 
   const redraw = (
-    highlights:Highlight[], 
-    viewportBounds: ViewportBounds,
+    highlights: Highlight[], 
+    _: ViewportBounds,
     currentStyle?: HighlightStyleExpression,
-    styleOverrides?: Map<string, HighlightStyleExpression>,
-    force?: boolean
+    __?: Map<string, HighlightStyleExpression>,
+    ___?: boolean
   ) => {
     // Next set of rendered annotation IDs and selections
     const nextRendered = new Set(highlights.map(h => h.annotation.id));
@@ -80,7 +80,7 @@ export const createCSSHighlightPainter = (): Painter => {
     // Could be improved further by (re-)setting only annotations that
     // have changes.
     highlights.forEach(({ annotation }) => {
-      const ranges = annotation.target.selector.map(s => s.range);
+      const ranges = annotation.target.selector.map((s: RevivedTextSelectorLike) => s.range);
 
       // @ts-ignore
       const highlights = new Highlight(...ranges);
@@ -113,8 +113,8 @@ export const createCSSHighlightPainter = (): Painter => {
 
 }
 
-export const createCSSHighlightRenderer: RendererFactory<TextAnnotation> = (
+export const createCSSHighlightRenderer: RendererFactory<TextAnnotationLike> = (
   container: HTMLElement,
-  state: TextAnnotatorState<TextAnnotation, any>,
+  state: TextAnnotatorState<TextAnnotationLike, any>,
   viewport: ViewportState
 ) => createRenderer(createCSSHighlightPainter(), container, state, viewport);

--- a/packages/text-annotator/src/rendering/renderer-inline-markup/index.ts
+++ b/packages/text-annotator/src/rendering/renderer-inline-markup/index.ts
@@ -1,1 +1,0 @@
-// For future use

--- a/packages/text-annotator/src/rendering/renderer-spans/spans-renderer.ts
+++ b/packages/text-annotator/src/rendering/renderer-spans/spans-renderer.ts
@@ -34,7 +34,7 @@ const createSpansPainter = (container: HTMLElement): Painter => {
     styleOverrides?: Map<string, HighlightStyleExpression>,
     force?: boolean
   ) => {
-    const startTime = performance.now();
+    // const startTime = performance.now();
 
     const noChanges = dequal(currentRendered, highlights);
 
@@ -94,7 +94,7 @@ const createSpansPainter = (container: HTMLElement): Painter => {
 
     currentRendered = highlights;
 
-    console.log(`Took ${performance.now() - startTime} ms`);
+    // console.log(`Took ${performance.now() - startTime} ms`);
   }
 
   const setVisible = (visible: boolean) => {

--- a/packages/text-annotator/src/selection-handler.ts
+++ b/packages/text-annotator/src/selection-handler.ts
@@ -5,7 +5,7 @@ import { poll } from 'poll';
 import { Origin } from '@annotorious/core';
 import type { Filter, Lifecycle, Selection, User } from '@annotorious/core';
 import type { TextAnnotatorState } from './state';
-import type { TextAnnotation, TextAnnotationTarget } from './model';
+import type { RevivedTextAnnotationLike, RevivedTextAnnotationTargetLike, TextAnnotationLike } from './model';
 import type { AnnotatingMode } from './text-annotator';
 import type { TextAnnotatorOptions } from './text-annotator-options';
 import { rangeToSelector } from './utils/annotation';
@@ -31,11 +31,11 @@ const SELECTION_KEYS = [
   SELECT_ALL
 ];
 
-export const createSelectionHandler = <T extends TextAnnotation>(
+export const createSelectionHandler = (
   container: HTMLElement,
-  state: TextAnnotatorState<TextAnnotation, any>,
-  lifecycle: Lifecycle<TextAnnotation, any>,
-  options: TextAnnotatorOptions<TextAnnotation, any>
+  state: TextAnnotatorState<RevivedTextAnnotationLike, any>,
+  lifecycle: Lifecycle<TextAnnotationLike, any>,
+  options: TextAnnotatorOptions<TextAnnotationLike, any>
 ) => {
   const { store, selection } = state;
 
@@ -54,11 +54,11 @@ export const createSelectionHandler = <T extends TextAnnotation>(
 
   let annotatingMode: AnnotatingMode = 'CREATE_NEW';
 
-  let currentTarget: TextAnnotationTarget | undefined;
+  let currentTarget: RevivedTextAnnotationTargetLike | undefined;
 
   // Only used if allowModifierSelect === true or if
   // annotatingMode === 'ADD_TO_CURRENT' | 'REPLACE_CURRENT'
-  let targetToModify: TextAnnotationTarget | undefined;
+  let targetToModify: RevivedTextAnnotationTargetLike | undefined;
 
   let isLeftClick: boolean | undefined;
 

--- a/packages/text-annotator/src/state/spatial-tree.ts
+++ b/packages/text-annotator/src/state/spatial-tree.ts
@@ -1,10 +1,17 @@
 import RBush from 'rbush';
 import type { Store } from '@annotorious/core';
 import { createNanoEvents, type Unsubscribe } from 'nanoevents';
-import type { TextAnnotationLike, TextAnnotationTarget, TextAnnotationTargetLike, TextSelector } from '../model';
 import type { AnnotationRects } from '../state/text-annotation-store';
-import { isRevived, reviveSelector } from '../utils/annotation';
 import { mergeClientRects, getHighlightClientRects, toParentBounds } from '../utils/highlight'; 
+import { reviveTextSelector } from '../utils/annotation';
+import type { 
+  RevivedTextAnnotationLike,
+  RevivedTextSelectorLike, 
+  TextAnnotationLike, 
+  TextAnnotationTarget, 
+  TextAnnotationTargetLike, 
+  TextSelector 
+} from '../model';
 
 interface IndexedHighlightRect {
 
@@ -36,7 +43,8 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
   store: Store<T>,
   container: HTMLElement,
   hMergeTolerance?: number,
-  vMergeTolerance?: number
+  vMergeTolerance?: number,
+  selectorReviveFn?: (arg: T['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike
 ) => {
 
   const tree = new RBush<IndexedHighlightRect>();
@@ -48,7 +56,11 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
   // Helper: converts a single text annotation target to a list of hightlight rects
   const toItems = (target: TextAnnotationTargetLike, offset: DOMRect): IndexedHighlightRect[] => {
     const rects = target.selector.flatMap(s => {
-      const revivedRange = isRevived([s]) ? s.range : reviveSelector(s as TextSelector, container).range;
+      const revivedRange = (selectorReviveFn 
+        ? selectorReviveFn(s, container) 
+        : reviveTextSelector(s as TextSelector, container)
+      )?.range;
+
       return getHighlightClientRects(revivedRange);
     });
 
@@ -82,7 +94,7 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
     index.clear();
   }
 
-  const insert = (target: TextAnnotationTarget) => {
+  const insert = (target: TextAnnotationTargetLike) => {
     const rects = toItems(target, container.getBoundingClientRect());
     if (rects.length === 0) return;
 
@@ -90,7 +102,7 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
     index.set(target.annotation, rects);
   }
 
-  const remove = (target: TextAnnotationTarget) => {
+  const remove = (target: TextAnnotationTargetLike) => {
     const rects = index.get(target.annotation);
     if (rects) {
       rects.forEach(rect => tree.remove(rect));
@@ -98,12 +110,12 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
     }
   }
 
-  const update = (target: TextAnnotationTarget) => {
+  const update = (target: TextAnnotationTargetLike) => {
     remove(target);
     insert(target);
   }
 
-  const set = (targets: TextAnnotationTarget[], replace: boolean = true) => {
+  const set = (targets: TextAnnotationTargetLike[], replace: boolean = true) => {
     if (replace)
       clear();
 
@@ -179,7 +191,7 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
     minY: number, 
     maxX: number, 
     maxY: number,
-  ): AnnotationRects<T>[] => {
+  ): AnnotationRects<RevivedTextAnnotationLike<T>>[] => {
     // All rects in this area, regardless of annotation
     const rects = tree.search({ minX, minY, maxX, maxY });
 
@@ -189,7 +201,7 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
     // Resolve annotation IDs. Note that the tree could be slightly out of sync (because 
     // it updates by listening to changes, just like anyone else)
     return Array.from(annotationIds).map(annotationId => ({
-      annotation: store.getAnnotation(annotationId)!,
+      annotation: store.getAnnotation(annotationId) as RevivedTextAnnotationLike<T>,
       rects: getAnnotationRects(annotationId)
     })).filter(t => Boolean(t.annotation));
   }

--- a/packages/text-annotator/src/state/text-annotation-store.ts
+++ b/packages/text-annotator/src/state/text-annotation-store.ts
@@ -1,6 +1,6 @@
 import type { Unsubscribe } from 'nanoevents';
-import type { Annotation, Filter, Origin, Store } from '@annotorious/core';
-import type { TextAnnotation, TextAnnotationLike } from '../model';
+import type { Filter, Origin, Store } from '@annotorious/core';
+import type { RevivedTextAnnotationLike, TextAnnotation, TextAnnotationLike } from '../model';
 import type { SpatialTreeEvents } from '../state/spatial-tree';
 
 export interface TextAnnotationStore<T extends TextAnnotationLike = TextAnnotation> 
@@ -20,11 +20,11 @@ export interface TextAnnotationStore<T extends TextAnnotationLike = TextAnnotati
 
   getAnnotationRects(id: string): DOMRect[];
 
-  getAt(x: number, y: number, all: true, filter?: Filter): T[] | undefined;
-  getAt(x: number, y: number, all: false, filter?: Filter): T | undefined;
-  getAt(x: number, y: number, all?: boolean, filter?: Filter): T | T[] | undefined;
+  getAt(x: number, y: number, all: true, filter?: Filter): RevivedTextAnnotationLike<T>[] | undefined;
+  getAt(x: number, y: number, all: false, filter?: Filter): RevivedTextAnnotationLike<T>| undefined;
+  getAt(x: number, y: number, all?: boolean, filter?: Filter): RevivedTextAnnotationLike<T> | RevivedTextAnnotationLike<T>[] | undefined;
 
-  getIntersecting(minX: number, minY: number, maxX: number, maxY: number): AnnotationRects<T>[];
+  getIntersecting(minX: number, minY: number, maxX: number, maxY: number): AnnotationRects<RevivedTextAnnotationLike<T>>[];
 
   recalculatePositions(): void;
 

--- a/packages/text-annotator/src/state/text-annotator-state.ts
+++ b/packages/text-annotator/src/state/text-annotator-state.ts
@@ -1,4 +1,4 @@
-import type { Annotation, Filter, Store, ViewportState } from '@annotorious/core';
+import type { Filter, Store, ViewportState } from '@annotorious/core';
 import { 
   createHoverState, 
   createSelectionState, 
@@ -11,13 +11,14 @@ import type {
   SelectionState, 
   HoverState, 
 } from '@annotorious/core';
-import type { TextAnnotation, TextAnnotationLike, TextAnnotationTarget } from '../model';
+import { isRevived } from '../model';
+import type { RevivedTextAnnotationLike, RevivedTextSelectorLike, TextAnnotation, TextAnnotationLike, TextAnnotationTargetLike } from '../model';
 import { createSpatialTree, type SpatialTreeEvents } from '../state/spatial-tree';
 import type { AnnotationRects, TextAnnotationStore } from '../state/text-annotation-store';
-import { isRevived, reviveAnnotation, reviveTarget } from '../utils/annotation';
+import { reviveAnnotation, reviveTarget } from '../utils/annotation';
 import type { TextAnnotatorOptions } from '../text-annotator-options';
 
-export interface TextAnnotatorState<I extends TextAnnotationLike = TextAnnotation, E extends unknown = TextAnnotation> 
+export interface TextAnnotatorState<I extends TextAnnotationLike = TextAnnotationLike, E extends unknown = TextAnnotation> 
   extends Omit<AnnotatorState<I, E>, 'store'> {
 
   store: TextAnnotationStore<I>;
@@ -30,14 +31,21 @@ export interface TextAnnotatorState<I extends TextAnnotationLike = TextAnnotatio
 
 }
 
-export const createTextAnnotatorState = <I extends TextAnnotation = TextAnnotation, E extends unknown = TextAnnotation>(
+export const createTextAnnotatorState = <I extends TextAnnotationLike = TextAnnotation, E extends unknown = TextAnnotation>(
   container: HTMLElement,
-  opts: TextAnnotatorOptions<I, E>
+  opts: TextAnnotatorOptions<I, E>,
+  selectorReviveFn?: (arg: I['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike
 ): TextAnnotatorState<I, E> => {
 
   const store: Store<I> = createStore<I>();
 
-  const tree = createSpatialTree(store, container, opts.mergeHighlights?.horizontalTolerance, opts.mergeHighlights?.verticalTolerance);
+  const tree = createSpatialTree(
+    store, 
+    container, 
+    opts.mergeHighlights?.horizontalTolerance, 
+    opts.mergeHighlights?.verticalTolerance,
+    selectorReviveFn
+  );
 
   const selection = createSelectionState<I, E>(store, opts.userSelectAction, opts.adapter);
 
@@ -47,7 +55,7 @@ export const createTextAnnotatorState = <I extends TextAnnotation = TextAnnotati
 
   // Wrap store interface to intercept annotations and revive DOM ranges, if needed
   const addAnnotation = (annotation: I, origin = Origin.LOCAL): boolean => {
-    const revived = reviveAnnotation(annotation, container);
+    const revived = reviveAnnotation(annotation, container, selectorReviveFn);
 
     const isValid = isRevived(revived.target.selector);
     if (isValid)
@@ -89,22 +97,23 @@ export const createTextAnnotatorState = <I extends TextAnnotation = TextAnnotati
     return couldNotRevive;
   }
 
-  const updateTarget = (target: TextAnnotationTarget, origin = Origin.LOCAL) => {
+  const updateTarget = (target: TextAnnotationTargetLike, origin = Origin.LOCAL) => {
     const revived = reviveTarget(target, container);
     store.updateTarget(revived, origin);
   }
 
-  const bulkUpdateTargets = (targets: TextAnnotationTarget[], origin = Origin.LOCAL) => {
+  const bulkUpdateTargets = (targets: TextAnnotationTargetLike[], origin = Origin.LOCAL) => {
     const revived = targets.map(t => reviveTarget(t, container));
     store.bulkUpdateTargets(revived, origin);
   }
 
-  function getAt(x: number, y: number, all: true, filter?: Filter): I[] | undefined;
-  function getAt(x: number, y: number, all: false, filter?: Filter): I | undefined;
-  function getAt(x: number, y: number, all?: boolean, filter?: Filter): I | I[] | undefined {
+  function getAt(x: number, y: number, all: true, filter?: Filter): RevivedTextAnnotationLike<I>[] | undefined;
+  function getAt(x: number, y: number, all: false, filter?: Filter): RevivedTextAnnotationLike<I> | undefined;
+  function getAt(x: number, y: number, all?: boolean, filter?: Filter): RevivedTextAnnotationLike<I> | RevivedTextAnnotationLike<I>[] | undefined {
     const getAll = all || Boolean(filter);
 
-    const annotations = tree.getAt(x, y, getAll).map(id => store.getAnnotation(id)!).filter(Boolean);
+    const annotations = tree.getAt(x, y, getAll).map(id => 
+      store.getAnnotation(id) as RevivedTextAnnotationLike<I>).filter(Boolean);
 
     const filtered = filter ? annotations.filter(filter) : annotations;
 
@@ -124,7 +133,7 @@ export const createTextAnnotatorState = <I extends TextAnnotation = TextAnnotati
     minY: number,
     maxX: number,
     maxY: number,
-  ): AnnotationRects<I>[] => tree.getIntersecting(minX, minY, maxX, maxY);
+  ): AnnotationRects<RevivedTextAnnotationLike<I>>[] => tree.getIntersecting(minX, minY, maxX, maxY);
 
   const getAnnotationRects = (id: string): DOMRect[] => tree.getAnnotationRects(id);
 

--- a/packages/text-annotator/src/text-annotator-options.ts
+++ b/packages/text-annotator/src/text-annotator-options.ts
@@ -1,4 +1,4 @@
-import type { FormatAdapter, UserSelectActionExpression, User, Annotation } from '@annotorious/core';
+import type { FormatAdapter, UserSelectActionExpression, User } from '@annotorious/core';
 import type { HighlightStyleExpression, RendererFactory } from './rendering';
 import type { TextAnnotation, TextAnnotationLike } from './model';
 

--- a/packages/text-annotator/src/text-annotator.ts
+++ b/packages/text-annotator/src/text-annotator.ts
@@ -13,7 +13,7 @@ import {
 import type { HighlightStyleExpression, Renderer, RendererFactory } from './rendering';
 import { createSpansRenderer } from './rendering/renderer-spans';
 import { createCSSHighlightRenderer } from './rendering/renderer-css-highlight';
-import type { TextAnnotation, TextAnnotationLike } from './model';
+import type { RevivedTextAnnotationLike, TextAnnotation, TextAnnotationLike } from './model';
 import { 
   type TextAnnotationStore, 
   type TextAnnotatorState, 
@@ -70,7 +70,6 @@ export const createTextAnnotator = <I extends TextAnnotationLike = TextAnnotatio
     user: createAnonymousGuest()
   });
 
-  // @ts-ignore - temporary!
   const state: TextAnnotatorState<I, E> = createTextAnnotatorState<I, E>(container, opts);
 
   const { selection, viewport } = state;
@@ -79,7 +78,6 @@ export const createTextAnnotator = <I extends TextAnnotationLike = TextAnnotatio
 
   const undoStack = createUndoStack<I>(store as unknown as Store<I>);
 
-  // Not an ideal cast... but not sure what the best approach would be 
   const lifecycle = 
     createLifecycleObserver<I, E>(state as unknown as AnnotatorState<I, E>, undoStack, opts.adapter);
 
@@ -95,7 +93,6 @@ export const createTextAnnotator = <I extends TextAnnotationLike = TextAnnotatio
         : opts.renderer || USE_DEFAULT_RENDERER :
     null;
 
-  // Likewise: not an ideal cast...
   const renderer =
     useBuiltInRenderer === null ? (opts.renderer as RendererFactory<I>)(
       container, 
@@ -107,7 +104,7 @@ export const createTextAnnotator = <I extends TextAnnotationLike = TextAnnotatio
       viewport) :
     useBuiltInRenderer === 'CSS_HIGHLIGHTS' ? createCSSHighlightRenderer(
       container, 
-      state as unknown as TextAnnotatorState<TextAnnotation, E>, 
+      state as unknown as TextAnnotatorState<TextAnnotationLike, E>, 
       viewport) :
     undefined;
 
@@ -122,12 +119,11 @@ export const createTextAnnotator = <I extends TextAnnotationLike = TextAnnotatio
   if (opts.style)
     renderer.setStyle(opts.style);
 
-  // Likewise: not ideal casts...
   const selectionHandler = createSelectionHandler(
     container, 
-    state as unknown as TextAnnotatorState<TextAnnotation, E>, 
-    lifecycle as unknown as Lifecycle<TextAnnotation, E>,
-    opts as unknown as TextAnnotatorOptions<TextAnnotation, E>);
+    state as unknown as TextAnnotatorState<RevivedTextAnnotationLike, E>, 
+    lifecycle as unknown as Lifecycle<TextAnnotationLike, E>,
+    opts as unknown as TextAnnotatorOptions<TextAnnotationLike, E>);
 
   selectionHandler.setUser(currentUser);
 

--- a/packages/text-annotator/src/utils/annotation/range-to-selector.ts
+++ b/packages/text-annotator/src/utils/annotation/range-to-selector.ts
@@ -1,11 +1,11 @@
-import type { TextSelector } from '../../model';
+import type { RevivedTextSelector } from '../../model';
 import { getRangeAnnotatableContents } from '../dom';
 
 export const rangeToSelector = (
   range: Range,
   container: HTMLElement,
   offsetReferenceSelector?: string
-): TextSelector => {
+): RevivedTextSelector => {
   const rangeBefore = document.createRange();
 
   const offsetReference: HTMLElement = offsetReferenceSelector

--- a/packages/text-annotator/src/utils/annotation/revive-annotation.ts
+++ b/packages/text-annotator/src/utils/annotation/revive-annotation.ts
@@ -1,8 +1,14 @@
-import type { TextAnnotation, TextAnnotationTarget, TextSelector, TextSelectorLike } from '../../model';
+import { isRevived, isRevivedTarget } from '../../model';
 import { NOT_ANNOTATABLE_SELECTOR } from '../dom';
-
-export const isRevived = (selector: TextSelectorLike[]) =>
-  selector.every(s => s.range instanceof Range && !s.range.collapsed);
+import type { 
+  RevivedTextAnnotationLike, 
+  RevivedTextAnnotationTargetLike, 
+  RevivedTextSelector, 
+  RevivedTextSelectorLike, 
+  TextAnnotationLike, 
+  TextAnnotationTargetLike, 
+  TextSelector 
+} from '../../model';
 
 /**
  * Creates a new selector object with the revived DOM range from the given text annotation position
@@ -13,11 +19,13 @@ export const isRevived = (selector: TextSelectorLike[]) =>
  *
  * @returns the revived selector
  */
-export const reviveSelector = <T extends TextSelector>(selector: T, container: HTMLElement): T => {
-
+export const reviveTextSelector = <T extends TextSelector>(
+  selector: T, 
+  container: HTMLElement
+): RevivedTextSelector  => {
   const { start, end } = selector;
 
-  const offsetReference = selector.offsetReference || container;
+  const offsetReference = isRevived(selector) ? selector.offsetReference || container : container;
 
   const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, (node) =>
     node.parentElement?.closest(NOT_ANNOTATABLE_SELECTOR)
@@ -73,15 +81,24 @@ export const reviveSelector = <T extends TextSelector>(selector: T, container: H
 
 }
 
-export const reviveTarget = <T extends TextAnnotationTarget = TextAnnotationTarget>(target: T, container: HTMLElement): T =>
-  isRevived(target.selector)
+export const reviveTarget = <T extends TextAnnotationTargetLike>(
+  target: T, 
+  container: HTMLElement,
+  reviveFn: (arg: T['selector'][number], container: HTMLElement) => RevivedTextSelectorLike =
+    (s, c) => reviveTextSelector(s as TextSelector, c) as RevivedTextSelectorLike
+): RevivedTextAnnotationTargetLike<T> =>
+  isRevivedTarget(target)
     ? target
     : ({
       ...target,
-      selector: target.selector.map(s => s.range instanceof Range && !s.range.collapsed ? s : reviveSelector(s, container))
+      selector: target.selector.map(s => isRevived(s) ? s : reviveFn(s, container))
     });
 
-export const reviveAnnotation = <T extends TextAnnotation>(annotation: T, container: HTMLElement): T =>
-  isRevived(annotation.target.selector)
-    ? annotation
-    : ({ ...annotation, target: reviveTarget(annotation.target, container) });
+export const reviveAnnotation = <T extends TextAnnotationLike>(
+  annotation: T, 
+  container: HTMLElement,
+  reviveFn?: (arg: T['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike
+): RevivedTextAnnotationLike<T> =>
+  isRevivedTarget(annotation.target)
+    ? annotation as RevivedTextAnnotationLike<T>
+    : ({ ...annotation, target: reviveTarget(annotation.target, container, reviveFn) } as RevivedTextAnnotationLike<T>);

--- a/packages/text-annotator/src/utils/annotation/revive-annotation.ts
+++ b/packages/text-annotator/src/utils/annotation/revive-annotation.ts
@@ -25,7 +25,7 @@ export const reviveTextSelector = <T extends TextSelector>(
 ): RevivedTextSelector  => {
   const { start, end } = selector;
 
-  const offsetReference = (selector as unknown as RevivedTextSelectorLike).offsetReference || container;
+  const offsetReference = (selector as unknown as RevivedTextSelector).offsetReference || container;
   
   const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, (node) =>
     node.parentElement?.closest(NOT_ANNOTATABLE_SELECTOR)

--- a/packages/text-annotator/src/utils/annotation/revive-annotation.ts
+++ b/packages/text-annotator/src/utils/annotation/revive-annotation.ts
@@ -22,10 +22,10 @@ import type {
 export const reviveTextSelector = <T extends TextSelector>(
   selector: T, 
   container: HTMLElement
-): RevivedTextSelector  => {
+): RevivedTextSelector  => { 
   const { start, end } = selector;
 
-  const offsetReference = (selector as unknown as RevivedTextSelector).offsetReference || container;
+  const offsetReference = selector.offsetReference || container;
   
   const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, (node) =>
     node.parentElement?.closest(NOT_ANNOTATABLE_SELECTOR)

--- a/packages/text-annotator/src/utils/annotation/revive-annotation.ts
+++ b/packages/text-annotator/src/utils/annotation/revive-annotation.ts
@@ -25,8 +25,8 @@ export const reviveTextSelector = <T extends TextSelector>(
 ): RevivedTextSelector  => {
   const { start, end } = selector;
 
-  const offsetReference = isRevived(selector) ? selector.offsetReference || container : container;
-
+  const offsetReference = (selector as unknown as RevivedTextSelectorLike).offsetReference || container;
+  
   const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, (node) =>
     node.parentElement?.closest(NOT_ANNOTATABLE_SELECTOR)
       ? NodeFilter.FILTER_SKIP

--- a/packages/text-annotator/src/utils/annotation/scroll-into-view.ts
+++ b/packages/text-annotator/src/utils/annotation/scroll-into-view.ts
@@ -19,7 +19,7 @@ const getScrollParent = (el?: Element | null) => {
 // Executes scroll on an annotation with a valid DOM range selector
 const scroll = <I extends TextAnnotationLike = TextAnnotationLike>(
   store: TextAnnotationStore<I>,
-  target: RevivedTextAnnotationTargetLike,
+  target: RevivedTextAnnotationTargetLike<I['target']>,
   scrollParent: Element
 ) => {
   // Parent bounds and client (= visible) height

--- a/packages/text-annotator/src/utils/annotation/scroll-into-view.ts
+++ b/packages/text-annotator/src/utils/annotation/scroll-into-view.ts
@@ -1,5 +1,5 @@
 import type { TextAnnotationStore } from '../../state';
-import { isRevived, type RevivedTextAnnotationLike, type RevivedTextAnnotationTargetLike, type RevivedTextSelector, type TextAnnotation, type TextAnnotationLike } from '../../model';
+import type { RevivedTextAnnotationTargetLike, RevivedTextSelector, TextAnnotationLike } from '../../model';
 import { reviveTarget } from '../annotation';
 
 const getScrollParent = (el?: Element | null) => {

--- a/packages/text-annotator/src/utils/annotation/scroll-into-view.ts
+++ b/packages/text-annotator/src/utils/annotation/scroll-into-view.ts
@@ -1,5 +1,5 @@
 import type { TextAnnotationStore } from '../../state';
-import type { TextAnnotation } from '../../model';
+import { isRevived, type RevivedTextAnnotationTargetLike, type TextAnnotation, type TextAnnotationLike } from '../../model';
 import { reviveTarget } from '../annotation';
 
 const getScrollParent = (el?: Element | null) => {
@@ -17,9 +17,9 @@ const getScrollParent = (el?: Element | null) => {
 };
 
 // Executes scroll on an annotation with a valid DOM range selector
-const scroll = <I extends TextAnnotation = TextAnnotation>(
+const scroll = <I extends TextAnnotationLike = TextAnnotationLike>(
   store: TextAnnotationStore<I>,
-  target: I['target'],
+  target: RevivedTextAnnotationTargetLike,
   scrollParent: Element
 ) => {
   // Parent bounds and client (= visible) height
@@ -51,7 +51,7 @@ const scroll = <I extends TextAnnotation = TextAnnotation>(
   scrollParent.scroll({ top, left, behavior: 'smooth' });
 };
 
-export const scrollIntoView = <I extends TextAnnotation = TextAnnotation>(
+export const scrollIntoView = <I extends TextAnnotationLike = TextAnnotationLike>(
   container: HTMLElement, store: TextAnnotationStore<I>
 ) => <E extends Element = Element>(
   annotationOrId: string | I, scrollParentOrId?: string | E
@@ -62,7 +62,6 @@ export const scrollIntoView = <I extends TextAnnotation = TextAnnotation>(
   const scrollParent = scrollParentOrId
     ? typeof scrollParentOrId === 'string' ? document.getElementById(scrollParentOrId) : scrollParentOrId
     : getScrollParent(container);
-
 
   if (!scrollParent) {
     console.warn(`The scroll parent is missing for the annotation: ${id}`, { container });
@@ -77,19 +76,23 @@ export const scrollIntoView = <I extends TextAnnotation = TextAnnotation>(
   }
 
   // The first selector is the topmost one as well
-  const { range: annoRange } = current.target.selector[0];
-  if (annoRange && !annoRange.collapsed) {
-    scroll(store, current.target, scrollParent);
-    return true;
-  }
+  const selector = current.target.selector[0];
+  if (isRevived(selector)) {
+    const { range: annoRange } = selector;
+    if (annoRange && !annoRange.collapsed) {
+      scroll(store, current.target as RevivedTextAnnotationTargetLike, scrollParent);
+      return true;
+    }
+  } else {
+    // Try reviving now to account for lazy rendering
+    const revived = reviveTarget(current.target, container);
 
-  // Try reviving to account for lazy rendering
-  const revived = reviveTarget(current.target, container);
-  const { range: revivedAnnoRange } = revived.selector[0];
-  if (revivedAnnoRange && !revivedAnnoRange.collapsed) {
-    scroll(store, revived, scrollParent);
-    return true;
-  }
+    const { range: revivedAnnoRange } = revived.selector[0];
+    if (revivedAnnoRange && !revivedAnnoRange.collapsed) {
+      scroll(store, revived, scrollParent);
+      return true;
+    }
 
-  return false;
-};
+    return false;
+  }
+}

--- a/packages/text-annotator/src/utils/annotation/scroll-into-view.ts
+++ b/packages/text-annotator/src/utils/annotation/scroll-into-view.ts
@@ -1,5 +1,5 @@
 import type { TextAnnotationStore } from '../../state';
-import { isRevived, type RevivedTextAnnotationTargetLike, type TextAnnotation, type TextAnnotationLike } from '../../model';
+import { isRevived, type RevivedTextAnnotationLike, type RevivedTextAnnotationTargetLike, type RevivedTextSelector, type TextAnnotation, type TextAnnotationLike } from '../../model';
 import { reviveTarget } from '../annotation';
 
 const getScrollParent = (el?: Element | null) => {
@@ -68,7 +68,7 @@ export const scrollIntoView = <I extends TextAnnotationLike = TextAnnotationLike
     return false;
   }
 
-  // Get curren version of the annotation from the store
+  // Get current version of the annotation from the store
   const current = store.getAnnotation(id);
   if (!current) {
     console.warn(`The annotation is missing in the store: ${id}`);
@@ -76,23 +76,20 @@ export const scrollIntoView = <I extends TextAnnotationLike = TextAnnotationLike
   }
 
   // The first selector is the topmost one as well
-  const selector = current.target.selector[0];
-  if (isRevived(selector)) {
-    const { range: annoRange } = selector;
-    if (annoRange && !annoRange.collapsed) {
-      scroll(store, current.target as RevivedTextAnnotationTargetLike, scrollParent);
-      return true;
-    }
-  } else {
-    // Try reviving now to account for lazy rendering
-    const revived = reviveTarget(current.target, container);
-
-    const { range: revivedAnnoRange } = revived.selector[0];
-    if (revivedAnnoRange && !revivedAnnoRange.collapsed) {
-      scroll(store, revived, scrollParent);
-      return true;
-    }
-
-    return false;
+  const { range: annoRange } = (current.target.selector[0] as RevivedTextSelector);
+  if (annoRange && !annoRange.collapsed) {
+    scroll(store, current.target as RevivedTextAnnotationTargetLike, scrollParent);
+    return true;
   }
+
+  // Try reviving now to account for lazy rendering
+  const revived = reviveTarget(current.target, container);
+  const { range: revivedAnnoRange } = revived.selector[0];
+  if (revivedAnnoRange && !revivedAnnoRange.collapsed) {
+    scroll(store, revived, scrollParent);
+    return true;
+  }
+
+  return false;
+  
 }

--- a/packages/text-annotator/test/model/w3c/w3c-text-format-adapter.test.ts
+++ b/packages/text-annotator/test/model/w3c/w3c-text-format-adapter.test.ts
@@ -3,19 +3,22 @@ import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import { textAnnotation, incompleteTextAnnotation } from './fixtures';
 import {
   parseW3CTextAnnotation,
-  reviveSelector,
+  reviveTextSelector,
   serializeW3CTextAnnotation,
+  type AnnotationBody,
+  type TextSelector,
+  type W3CTextAnnotationTarget,
 } from '../../../src';
 
 beforeEach(async () => {
   const dom = await JSDOM.fromFile(`${process.cwd()}/test/index.html`);
   global.document = dom.window.document;
-  global.contentContainer = global.document.getElementById('content');
+  (global as any).contentContainer = global.document.getElementById('content');
 });
 
 afterEach(() => {
-  delete global.document;
-  delete global.contentContainer;
+  delete (global as any).document;
+  delete (global as any).contentContainer;
 });
 
 describe('parseW3CTextAnnotation', () => {
@@ -23,36 +26,47 @@ describe('parseW3CTextAnnotation', () => {
     const { parsed, error } = parseW3CTextAnnotation(textAnnotation);
     expect(error).toBeUndefined();
 
-    const fixtureBody = textAnnotation.body[0];
-    const fixtureTarget = textAnnotation.target[0];
+    const fixtureBody = (textAnnotation as any).body[0];
+    const fixtureTarget = (textAnnotation as any).target[0];
 
-    expect(parsed.bodies).toHaveLength(1);
-    expect(parsed.bodies[0].value).toBe(fixtureBody.value);
+    const bodies = parsed?.bodies as AnnotationBody[];
 
-    const { selector, created, creator } = parsed.target;
-    const { quote, start } = selector[0];
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].value).toBe(fixtureBody.value);
+
+    const { selector, created, creator } = parsed!.target;
+    const { quote, start } = selector[0] as any;
 
     expect(quote).toStrictEqual(fixtureTarget.selector[0].exact);
     expect(start).toStrictEqual(fixtureTarget.selector[1].start);
-    expect(created.getTime()).toEqual(new Date(textAnnotation.created).getTime());
-    expect(creator.id).toEqual(textAnnotation.creator.id);
+    expect(created?.getTime()).toEqual(new Date(textAnnotation.created!).getTime());
+    expect(creator?.id).toEqual(textAnnotation.creator!.id);
   });
 
   it('should return an error if the selector is incomplete', () => {
     const { parsed, error } = parseW3CTextAnnotation(incompleteTextAnnotation);
     expect(parsed).toBeUndefined();
     expect(error).toBeDefined();
-    expect(error.message).toContain('Missing selector');
+    expect(error!.message).toContain('Missing selector');
   });
 
   it('should serialize the sample annotation correctly', () => {
     const { parsed, error } = parseW3CTextAnnotation(textAnnotation);
-    parsed.target.selector = parsed.target.selector.map(selector => reviveSelector(selector, global.contentContainer));
+    parsed!.target.selector = parsed!.target.selector.map(selector => 
+      reviveTextSelector(selector as TextSelector, (global as any).contentContainer));
+
     expect(error).toBeUndefined();
 
-    const serialized = serializeW3CTextAnnotation(parsed, textAnnotation.target[0].source, global.contentContainer);
-    expect(serialized.body).toEqual(textAnnotation.body);
+    const testTarget = (textAnnotation.target as W3CTextAnnotationTarget[])[0];
 
-    expect(serialized.target[0].selector).toEqual(textAnnotation.target[0].selector);
+    const serialized = serializeW3CTextAnnotation(
+      parsed!, 
+      testTarget.source, 
+      (global as any).contentContainer);
+
+    expect(serialized.body).toEqual(textAnnotation.body);
+    
+    const serializedTarget = (serialized.target as W3CTextAnnotationTarget[])[0];
+    expect(serializedTarget.selector).toEqual(testTarget.selector);
   });
 });


### PR DESCRIPTION
## In this PR

Attempt to clean up the type model after the introduction of `TextAnnotationLike` and TEI annotations that have no `start` and `end` fields in their selectors.