### PR TITLE
Moved `selectorReviveFn` option from `createTextAnnotatorState` parameter to `TextAnnotatorOptions`

### DIFF
--- a/packages/text-annotator/src/state/text-annotator-state.ts
+++ b/packages/text-annotator/src/state/text-annotator-state.ts
@@ -12,7 +12,7 @@ import type {
   HoverState, 
 } from '@annotorious/core';
 import { isRevived } from '../model';
-import type { RevivedTextAnnotationLike, RevivedTextSelectorLike, TextAnnotation, TextAnnotationLike, TextAnnotationTargetLike } from '../model';
+import type { RevivedTextAnnotationLike, TextAnnotation, TextAnnotationLike, TextAnnotationTargetLike } from '../model';
 import { createSpatialTree, type SpatialTreeEvents } from '../state/spatial-tree';
 import type { AnnotationRects, TextAnnotationStore } from '../state/text-annotation-store';
 import { reviveAnnotation, reviveTarget } from '../utils/annotation';
@@ -33,18 +33,17 @@ export interface TextAnnotatorState<I extends TextAnnotationLike = TextAnnotatio
 
 export const createTextAnnotatorState = <I extends TextAnnotationLike = TextAnnotation, E extends unknown = TextAnnotation>(
   container: HTMLElement,
-  opts: TextAnnotatorOptions<I, E>,
-  selectorReviveFn?: (arg: I['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike
+  opts: TextAnnotatorOptions<I, E>
 ): TextAnnotatorState<I, E> => {
 
   const store: Store<I> = createStore<I>();
 
   const tree = createSpatialTree(
-    store, 
-    container, 
-    opts.mergeHighlights?.horizontalTolerance, 
+    store,
+    container,
+    opts.mergeHighlights?.horizontalTolerance,
     opts.mergeHighlights?.verticalTolerance,
-    selectorReviveFn
+    opts.selectorReviveFn
   );
 
   const selection = createSelectionState<I, E>(store, opts.userSelectAction, opts.adapter);
@@ -55,7 +54,7 @@ export const createTextAnnotatorState = <I extends TextAnnotationLike = TextAnno
 
   // Wrap store interface to intercept annotations and revive DOM ranges, if needed
   const addAnnotation = (annotation: I, origin = Origin.LOCAL): boolean => {
-    const revived = reviveAnnotation(annotation, container, selectorReviveFn);
+    const revived = reviveAnnotation(annotation, container, opts.selectorReviveFn);
 
     const isValid = isRevived(revived.target.selector);
     if (isValid)

--- a/packages/text-annotator/src/text-annotator-options.ts
+++ b/packages/text-annotator/src/text-annotator-options.ts
@@ -1,6 +1,6 @@
 import type { FormatAdapter, UserSelectActionExpression, User } from '@annotorious/core';
 import type { HighlightStyleExpression, RendererFactory } from './rendering';
-import type { TextAnnotation, TextAnnotationLike } from './model';
+import type { RevivedTextSelectorLike, TextAnnotation, TextAnnotationLike } from './model';
 
 export interface TextAnnotatorOptions<I extends TextAnnotationLike = TextAnnotation, E extends unknown = TextAnnotation> {
 
@@ -9,6 +9,12 @@ export interface TextAnnotatorOptions<I extends TextAnnotationLike = TextAnnotat
   allowModifierSelect?: boolean;
 
   annotatingEnabled?: boolean;
+
+  /**
+   * Custom function that turns a stored selector into a revived one (with a live DOM `range`).
+   * Used by sub-formats such as PDF to map their selector shape to a text range.
+   */
+  selectorReviveFn?: (arg: I['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike;
 
   /**
    * Determines whether an active selection should be dismissed


### PR DESCRIPTION
## Relations
Applies the suggestion from https://github.com/recogito/text-annotator-js/pull/271#discussion_r3325042400

> Should the `selectorReviveFn` come as part of the `opts`? That seems to be an easier option than tweaking the positional arguments in the future.

> Yes, definitely. I was planning that as a 2nd step. (It's in fact already implemented that way in the [lazy-reviving](https://github.com/recogito/text-annotator-js/tree/lazy-reviving) branch - which is just a messy playground though.)

###### Soomo Staged