### PR TITLE
Added generic type parameter to `HighlightStyleExpression`

### DIFF
--- a/packages/pdf-annotator-react/src/pdf-annotator.tsx
+++ b/packages/pdf-annotator-react/src/pdf-annotator.tsx
@@ -12,7 +12,7 @@ export type PDFAnnotatorProps = TextAnnotatorOptions<PDFAnnotation, PDFAnnotatio
 
   filter?: Filter;
 
-  style?: HighlightStyleExpression
+  style?: HighlightStyleExpression<PDFAnnotation>
 
   pdfUrl: string;
 

--- a/packages/pdf-annotator/src/pdf-annotator.ts
+++ b/packages/pdf-annotator/src/pdf-annotator.ts
@@ -34,7 +34,7 @@ export interface PDFAnnotator extends Omit<TextAnnotator<PDFAnnotation, PDFAnnot
 
   setScale(scale: PDFScale | number): number;
 
-  setStyle(style?: HighlightStyleExpression, id?: string): void;
+  setStyle(style?: HighlightStyleExpression<PDFAnnotation>, id?: string): void;
 
   zoomIn(percentage?: number): number;
 
@@ -139,7 +139,7 @@ export const createPDFAnnotator = (
     }
   }
 
-  const setStyle = (style: HighlightStyleExpression | undefined, id?: string) =>
+  const setStyle = (style: HighlightStyleExpression<PDFAnnotation> | undefined, id?: string) =>
     renderer.setStyle(style, id);
 
   const setUser = (user: User) => {

--- a/packages/text-annotator/src/rendering/base-renderer.ts
+++ b/packages/text-annotator/src/rendering/base-renderer.ts
@@ -25,7 +25,7 @@ export interface Renderer {
 
   redraw(force?: boolean): void;
 
-  setStyle(style?: HighlightStyleExpression, id?: string): void;
+  setStyle<I extends TextAnnotationLike = TextAnnotationLike>(style?: HighlightStyleExpression<I>, id?: string): void;
 
   setFilter(filter?: Filter<any>): void;
 
@@ -139,14 +139,14 @@ export const createRenderer = <T extends TextAnnotatorState<TextAnnotationLike, 
     }, 1);
   }), 10);
 
-  const setStyle = (style?: HighlightStyleExpression, id?: string) => {
+  const setStyle = <I extends TextAnnotationLike = TextAnnotationLike>(style?: HighlightStyleExpression<I>, id?: string) => {
     if (id) {
       if (style)
-        styleOverrides.set(id, style);
+        styleOverrides.set(id, style as HighlightStyleExpression);
       else
         styleOverrides.delete(id);
     } else {
-      currentStyle = style;
+      currentStyle = style as HighlightStyleExpression | undefined;
     }
 
     // console.log('[base-renderer] redrawing style change');

--- a/packages/text-annotator/src/rendering/highlight-style.ts
+++ b/packages/text-annotator/src/rendering/highlight-style.ts
@@ -21,8 +21,8 @@ export interface HighlightStyle {
 
 }
 
-export type HighlightStyleExpression = HighlightStyle 
-  | (<I extends TextAnnotationLike = TextAnnotationLike>(annotation: I, state: AnnotationState, zIndex?: number) => HighlightStyle | undefined);
+export type HighlightStyleExpression<I extends TextAnnotationLike = TextAnnotationLike> = HighlightStyle
+  | ((annotation: I, state: AnnotationState, zIndex?: number) => HighlightStyle | undefined);
 
 export const DEFAULT_STYLE: HighlightStyle = { 
   fill: 'rgb(0, 128, 255)', 

--- a/packages/text-annotator/src/text-annotator-options.ts
+++ b/packages/text-annotator/src/text-annotator-options.ts
@@ -37,7 +37,7 @@ export interface TextAnnotatorOptions<I extends TextAnnotationLike = TextAnnotat
 
   selectionMode?: 'shortest' | 'all';
 
-  style?: HighlightStyleExpression;
+  style?: HighlightStyleExpression<I>;
 
   user?: User;
 

--- a/packages/text-annotator/src/text-annotator.ts
+++ b/packages/text-annotator/src/text-annotator.ts
@@ -40,7 +40,7 @@ export interface TextAnnotator<I extends TextAnnotationLike = TextAnnotation, E 
 
   renderer: Renderer;
 
-  setStyle(style?: HighlightStyleExpression, id?: string): void;
+  setStyle(style?: HighlightStyleExpression<I>, id?: string): void;
 
   // Returns true if successful (or false if the annotation is not currently rendered)
   scrollIntoView(annotationOrId: I | string, scrollParentOrId?: string | Element): boolean;


### PR DESCRIPTION
## Issue
`HighlightStyleExpression` was declared as a non-generic type alias where the `I` type parameter was scoped to the function overload inside the union, not to the type alias itself. This made it impossible for consuming apps to parameterize it with a custom annotation type. The obvious workaround:
```ts
type HighlightStyleFn = Extract<HighlightStyleExpression, Function>;
const style: HighlightStyleFn<WebtextsAnnotation> = ...
// TS2315: Type 'HighlightStyleFn' is not generic.
```
fails because `Extract` produces a non-generic function type, the inner `<I>` is erased.

Additionally, even though `TextAnnotatorOptions<I>` and `TextAnnotator<I>` carried a concrete annotation type parameter, style and `setStyle` were still typed as the unparameterized `HighlightStyleExpression`, so the narrow annotation type was never forwarded to styling callbacks.

## Changes Made

- Made `HighlightStyleExpression<I>` a generic type alias (defaults to `TextAnnotationLike`). Previously `I` was scoped to the inner function signature, so the parameter was erased at the alias level and couldn't be specialized or extracted.
- Threaded `I` through `TextAnnotatorOptions.style`, `TextAnnotator.setStyle`, `PDFAnnotator.setStyle`, and the React `PDFAnnotator`'s `style` prop, so the annotator's annotation type now reaches styling callbacks.
- Made the internal `Renderer.setStyle` method-level generic to accept any narrowed expression, with a single cast at the boundary.

Fully backwards-compatible — all new type parameters default to the previously implicit type. No runtime changes.

###### Soomo Staged