### PR TITLE
Added trusted packages to the `allowScripts` list

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
   ],
   "devDependencies": {
     "vite-plugin-dts": "^4.5.4"
+  },
+  "allowScripts": {
+    "esbuild@0.27.7": true,
+    "fsevents@2.3.3": true
   }
 }


### PR DESCRIPTION
## Context
In the `NPM` `11.16.0`[^1], a new script was added: [`npm-approve-scripts`](https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts).

In addition, the opt-in install script policy has started to roll out:
> **Install behaviour is unchanged.** Scripts still run as they always have. The only Phase 1 user-visible change is one advisory block at the end of `npm install` listing packages whose install scripts haven't been reviewed via the new `allowScripts` field in `package.json`. A future release will turn that advisory into an actual block.

This can prevent major security breaches that have plagued the JS ecosystem lately.

## Issue
Currently, when I install dependencies in `text-annotator-js`, I'll be greeted with a warning that the `esbuild` and `fsevents` `postinstall` scripts are ignored. IIUC, they are needed to install platform-specific stuff.

## Changes Made
Added the known and trusted deps to the `alllowScripts` list.

[^1]: Full release notes: https://www.gitclear.com/open_repos/npm/cli/release/v11.16.0


###### Soomo Staged