### PR TITLE
Bumped `annotorious/*` dependencies to `3.8.6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,12 @@
       }
     },
     "node_modules/@annotorious/annotorious": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.8.3.tgz",
-      "integrity": "sha512-9N94zU1w/89AU4TU/gyj4OBlR3fOKkqb4Y3g3ByQBqkd8+qLW7FCJxCovM9fyQtS8BdlDL84vi7iRFqVLPljCg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.8.6.tgz",
+      "integrity": "sha512-ym5EiqY88dbMmuGcSGwRjEmFtlSA1MYEz8RUvfLjLnHWXrdyY8JlosGRDGw8hEdO5jS9mTQBOF2UvXLipHwpZA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/core": "3.8.3",
+        "@annotorious/core": "3.8.6",
         "dequal": "^2.0.3",
         "rbush": "^4.0.1",
         "simplify-js": "^1.2.4",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@annotorious/core": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.8.3.tgz",
-      "integrity": "sha512-1W/gkvVqLBJ9prrmpPFBUWAEipVxBSc4M/zSwqE4eabPs2/moULiAyUKh4hIipKjZyWYWJI5GEl/Di3HLj606A==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.8.6.tgz",
+      "integrity": "sha512-9Lc4YjTShDw552Jedwf6ZI0Q9nfn5U8CGRWy06/cnd3ki824zca1XvtSC7BYzlemnbrZEfqllUWBQ75ab9SmeQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "dequal": "^2.0.3",
@@ -46,13 +46,13 @@
       }
     },
     "node_modules/@annotorious/openseadragon": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.8.3.tgz",
-      "integrity": "sha512-qWKjVRDdddK3sU0hzAt297swFx5fwe/EU07fM/NKn5cl4nttTqtFA90H7cHYjozIXWqboeg/DdGTMwF/HbM7gg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.8.6.tgz",
+      "integrity": "sha512-hHidpjY2ZJjqhfIwY2sdPhcV2suS4lwwbevL1MjP6J7qF96dq45cRSdYzwgVV/ghRLorKeLszqsnPCZe1+RYWA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "3.8.3",
-        "@annotorious/core": "3.8.3",
+        "@annotorious/annotorious": "3.8.6",
+        "@annotorious/core": "3.8.6",
         "pixi.js": "^7.4.3",
         "uuid": "^14.0.0"
       },
@@ -61,14 +61,14 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.8.3.tgz",
-      "integrity": "sha512-nva/5umTGYlRdzS/o9oX6WbHMOOPm2LhaY3EDmyCpqhCIV/204cPKNW0UYdLagfOXwBWZStxW/KoXBuoiVQnyg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.8.6.tgz",
+      "integrity": "sha512-8lhbimDoRU7TVyRTxruHwR7YM9KSLe0Cl1Q8BuoOclZu2ekBuauFsRA2SstdWRu3WvmaLQAAh+waR3TAaUnOPQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "3.8.3",
-        "@annotorious/core": "3.8.3",
-        "@annotorious/openseadragon": "3.8.3",
+        "@annotorious/annotorious": "3.8.6",
+        "@annotorious/core": "3.8.6",
+        "@annotorious/openseadragon": "3.8.6",
         "@floating-ui/react": "^0.27.19",
         "dequal": "^2.0.3"
       },
@@ -582,7 +582,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -600,7 +599,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -618,7 +616,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -636,7 +633,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -654,7 +650,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -672,7 +667,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -690,7 +684,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -708,7 +701,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -726,7 +718,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -744,7 +735,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -762,7 +752,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -780,7 +769,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -798,7 +786,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -816,7 +803,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -834,7 +820,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -852,7 +837,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -870,7 +854,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -888,7 +871,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -906,7 +888,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -924,7 +905,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -942,7 +922,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -960,7 +939,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -978,7 +956,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -996,7 +973,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1014,7 +990,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1032,7 +1007,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1921,8 +1895,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.61.1",
@@ -1936,8 +1909,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.61.1",
@@ -1951,8 +1923,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.61.1",
@@ -1966,8 +1937,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.61.1",
@@ -1981,8 +1951,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.61.1",
@@ -1996,8 +1965,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.61.1",
@@ -2011,8 +1979,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.61.1",
@@ -2026,8 +1993,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.61.1",
@@ -2041,8 +2007,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.61.1",
@@ -2056,8 +2021,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.61.1",
@@ -2071,8 +2035,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.61.1",
@@ -2086,8 +2049,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.61.1",
@@ -2101,8 +2063,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.61.1",
@@ -2116,8 +2077,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.61.1",
@@ -2131,8 +2091,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.61.1",
@@ -2146,8 +2105,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.61.1",
@@ -2161,8 +2119,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.61.1",
@@ -2176,8 +2133,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.61.1",
@@ -2191,8 +2147,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.61.1",
@@ -2206,8 +2161,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.61.1",
@@ -2221,8 +2175,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.61.1",
@@ -2236,8 +2189,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.61.1",
@@ -2251,8 +2203,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.61.1",
@@ -2266,8 +2217,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.61.1",
@@ -2281,8 +2231,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rushstack/node-core-library": {
       "version": "5.23.1",
@@ -3416,7 +3365,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -4295,14 +4243,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -5024,7 +4972,7 @@
       "version": "4.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/core": "^3.8.2",
+        "@annotorious/core": "^3.8.6",
         "@recogito/text-annotator": "4.2.2",
         "pdfjs-dist": "^6.0.227"
       },
@@ -5053,7 +5001,7 @@
         "vite-tsconfig-paths": "^5.1.4"
       },
       "peerDependencies": {
-        "@annotorious/react": "^3.8.2",
+        "@annotorious/react": "^3.8.6",
         "@recogito/pdf-annotator": "4.2.2",
         "pdfjs-dist": "^6.0.227",
         "react": ">= ^18.x || >= ^19.x",
@@ -5065,7 +5013,7 @@
       "version": "4.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/core": "^3.8.2",
+        "@annotorious/core": "^3.8.6",
         "colord": "^2.9.3",
         "debounce": "^3.0.0",
         "dequal": "^2.0.3",
@@ -5090,8 +5038,8 @@
       "version": "4.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/core": "^3.8.2",
-        "@annotorious/react": "^3.8.2",
+        "@annotorious/core": "^3.8.6",
+        "@annotorious/react": "^3.8.6",
         "@floating-ui/react": "^0.27.19",
         "@recogito/text-annotator": "4.2.2",
         "@recogito/text-annotator-tei": "4.2.2",
@@ -5130,7 +5078,7 @@
         "vite": "^7.3.5"
       },
       "peerDependencies": {
-        "@annotorious/core": "^3.8.2",
+        "@annotorious/core": "^3.8.6",
         "@recogito/text-annotator": "4.2.2"
       }
     }

--- a/packages/pdf-annotator-react/package.json
+++ b/packages/pdf-annotator-react/package.json
@@ -44,7 +44,7 @@
     "vite-tsconfig-paths": "^5.1.4"
   },
   "peerDependencies": {
-    "@annotorious/react": "^3.8.2",
+    "@annotorious/react": "^3.8.6",
     "@recogito/pdf-annotator": "4.2.2",
     "pdfjs-dist": "^6.0.227",
     "react": ">= ^18.x || >= ^19.x",

--- a/packages/pdf-annotator/package.json
+++ b/packages/pdf-annotator/package.json
@@ -39,7 +39,7 @@
     "vite-plugin-dts": "^4.5.4"
   },
   "dependencies": {
-    "@annotorious/core": "^3.8.2",
+    "@annotorious/core": "^3.8.6",
     "@recogito/text-annotator": "4.2.2",
     "pdfjs-dist": "^6.0.227"
   }

--- a/packages/text-annotator-react/package.json
+++ b/packages/text-annotator-react/package.json
@@ -45,8 +45,8 @@
     }
   },
   "dependencies": {
-    "@annotorious/core": "^3.8.2",
-    "@annotorious/react": "^3.8.2",
+    "@annotorious/core": "^3.8.6",
+    "@annotorious/react": "^3.8.6",
     "@floating-ui/react": "^0.27.19",
     "@recogito/text-annotator": "4.2.2",
     "@recogito/text-annotator-tei": "4.2.2",

--- a/packages/text-annotator-tei/package.json
+++ b/packages/text-annotator-tei/package.json
@@ -31,7 +31,7 @@
     "vite": "^7.3.5"
   },
   "peerDependencies": {
-    "@annotorious/core": "^3.8.2",
+    "@annotorious/core": "^3.8.6",
     "@recogito/text-annotator": "4.2.2"
   }
 }

--- a/packages/text-annotator/package.json
+++ b/packages/text-annotator/package.json
@@ -35,7 +35,7 @@
     "vitest": "^4.1.8"
   },
   "dependencies": {
-    "@annotorious/core": "^3.8.2",
+    "@annotorious/core": "^3.8.6",
     "colord": "^2.9.3",
     "debounce": "^3.0.0",
     "dequal": "^2.0.3",

--- a/plugins/awareness/package.json
+++ b/plugins/awareness/package.json
@@ -24,8 +24,8 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@annotorious/core": "^3.8.2",
-    "@annotorious/react": "^3.8.2",
+    "@annotorious/core": "^3.8.6",
+    "@annotorious/react": "^3.8.6",
     "@recogito/react-text-annotator": "^4.2.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
## Changes Made
Bumped all the `annotorious/*` dependencies to the latest `3.8.6` version. 

That pulls in improved behavior of the `.setAnnotations` method: https://github.com/annotorious/annotorious/pull/607


###### Soomo Staged