### PR TITLE
Introduced new `syncAnnotations` method override

### DIFF
--- a/packages/text-annotator/src/state/text-annotation-store.ts
+++ b/packages/text-annotator/src/state/text-annotation-store.ts
@@ -3,16 +3,21 @@ import type { Filter, Origin, Store } from '@annotorious/core';
 import type { RevivedTextAnnotationLike, TextAnnotation, TextAnnotationLike } from '../model';
 import type { SpatialTreeEvents } from '../state/spatial-tree';
 
-export interface TextAnnotationStore<T extends TextAnnotationLike = TextAnnotation> 
-  extends Omit<Store<T>, 'addAnnotation' | 'bulkAddAnnotations' | 'bulkUpsertAnnotations'> {
+export interface TextAnnotationStore<T extends TextAnnotationLike = TextAnnotation>
+  extends Omit<Store<T>, 'addAnnotation' | 'bulkAddAnnotations' | 'bulkUpsertAnnotations' | 'syncAnnotations'> {
 
   // Minor changes to default Annotorious store - text store returns feedback
   // on annotations that failed to render, to support lazy document loading scenarios
   addAnnotation(annotation: T, origin?: Origin): boolean;
 
+  /**
+   * @deprecated use {@link syncAnnotations} (replace) or {@link bulkUpsertAnnotations} (merge) instead.
+   */
   bulkAddAnnotations(annotations: T[], replace: boolean, origin?: Origin): T[];
 
   bulkUpsertAnnotations(annotations: T[], origin?: Origin): T[];
+
+  syncAnnotations(annotations: T[], origin?: Origin): T[];
 
   getAnnotationRects(id: string): DOMRect[];
 

--- a/packages/text-annotator/src/state/text-annotator-state.ts
+++ b/packages/text-annotator/src/state/text-annotator-state.ts
@@ -63,38 +63,41 @@ export const createTextAnnotatorState = <I extends TextAnnotationLike = TextAnno
     return isValid;
   }
 
-  const bulkAddAnnotations = (
-    annotations: I[], 
-    replace = true, 
-    origin = Origin.LOCAL
-  ): I[] => {
+  const reviveAll = (annotations: I[]): { revived: I[], couldNotRevive: I[] } => {
     const revived = annotations.map(a => reviveAnnotation<I>(a, container, opts.selectorReviveFn));
-
     // Initial page load might take some time. Retry for more robustness.
     const couldNotRevive = revived.filter(a => !isRevived(a.target.selector));
-    store.bulkAddAnnotations(revived, replace, origin);
-
-    return couldNotRevive;
+    return { revived, couldNotRevive };
   }
-  
-  const bulkUpsertAnnotations = (
-    annotations: I[], 
+
+  const syncAnnotations = (
+    annotations: I[],
     origin = Origin.LOCAL
   ): I[] => {
-    const revived = annotations.map(a => reviveAnnotation(a, container, opts.selectorReviveFn));
-
-    // Initial page load might take some time. Retry for more robustness.
-    const couldNotRevive = revived.filter(a => !isRevived(a.target.selector));
-    
-    revived.forEach(a => {
-      if (store.getAnnotation(a.id))
-        store.updateAnnotation(a, origin);
-      else 
-        store.addAnnotation(a, origin);
-    })
-
+    const { revived, couldNotRevive } = reviveAll(annotations);
+    store.syncAnnotations(revived, origin);
     return couldNotRevive;
   }
+
+  const bulkUpsertAnnotations = (
+    annotations: I[],
+    origin = Origin.LOCAL
+  ): I[] => {
+    const { revived, couldNotRevive } = reviveAll(annotations);
+    store.bulkUpsertAnnotations(revived, origin);
+    return couldNotRevive;
+  }
+
+  /**
+   * @deprecated use {@link syncAnnotations} (replace) or {@link bulkUpsertAnnotations} (merge) instead.
+   */
+  const bulkAddAnnotations = (
+    annotations: I[],
+    replace = true,
+    origin = Origin.LOCAL
+  ): I[] => replace
+    ? syncAnnotations(annotations, origin)
+    : bulkUpsertAnnotations(annotations, origin);
 
   const updateTarget = (target: TextAnnotationTargetLike, origin = Origin.LOCAL) => {
     const revived = reviveTarget(target, container);
@@ -167,6 +170,7 @@ export const createTextAnnotatorState = <I extends TextAnnotationLike = TextAnno
       getAt,
       recalculatePositions,
       onRecalculatePositions,
+      syncAnnotations,
       updateTarget
     },
     selection,


### PR DESCRIPTION
## Issue
Bridges the text-annotator-js store wrapper to the new `Store.syncAnnotations` API introduced in [annotorious/annotorious#607](https://github.com/annotorious/annotorious/pull/607) (and retained alongside the deprecated `bulkAddAnnotations` in [c24e5347](https://github.com/annotorious/annotorious/commit/c24e5347aa1d337ebdd9be2eee7404d5c2aab5f0)).

After [PR #607](https://github.com/annotorious/annotorious/pull/607), `createBaseAnnotator.setAnnotations(annotations, replace=true)` no longer calls `store.bulkAddAnnotations` — it routes through `store.syncAnnotations` for the replace path and `store.bulkUpsertAnnotations` for the merge path. 

Our wrapped store in `createTextAnnotatorState` only overrode `addAnnotation`, `bulkAddAnnotations`, and `bulkUpsertAnnotations` to run `reviveAnnotation(...)` (DOM range resurrection) before payloads hit the inner store. `syncAnnotations` was not wrapped, so the call fell through to the raw core method, **skipping revival entirely**. 
Un-revived selectors then failed the `isRevived(...)` filter in the spatial-tree observer and never rendered — annotations existed in the index but were invisible, and the selection-preservation benefit the upstream PR was designed to deliver was lost on the text-annotator path.

## Changes Made
Mirrored the upstream pattern across the text-annotator store wrapper so that every "set the full list of annotations" path goes through revival before reaching the core store.

- Added a revival-aware `syncAnnotations(annotations, origin)` to `createTextAnnotatorState` that revives, delegates to `store.syncAnnotations`, and returns the same `couldNotRevive` array the other bulk methods do. Wired it into the returned store object so `createBaseAnnotator.setAnnotations` now reaches the revival-aware wrapper. This is the load-bearing fix.
- Collapsed `bulkUpsertAnnotations` from its manual `getAnnotation` / `updateAnnotation` / `addAnnotation` loop down to a single `store.bulkUpsertAnnotations` delegation. The loop predated the upstream method and emitted N store events; the delegation emits one batched event, matching the semantics `setAnnotations` now expects.
- Reduced `bulkAddAnnotations` to a thin, `@deprecated` backwards-compat shim that branches into `syncAnnotations` or `bulkUpsertAnnotations` based on the `replace` flag — mirroring annotorious commit c24e5347. Existing external callers keep working unchanged.
- Extracted the shared "revive → split into couldNotRevive" step into a small `reviveAll` helper used by all three bulk methods.
- Updated the `TextAnnotationStore` interface to omit-and-redeclare `syncAnnotations` with the text-annotator's "returns un-revivable annotations" contract, and JSDoc-marked `bulkAddAnnotations` as deprecated pointing at the new methods.

As a result, periodic `setAnnotations` refreshes no longer dismiss the active selection or drop annotations from the rendered layer — the survivor set is updated in place via the core's diff-based reconciliation, and only genuinely-removed ids are torn down.