### PR TITLE
Support selector splitting in `selectorReviveFn`

### DIFF
--- a/packages/text-annotator/src/state/spatial-tree.ts
+++ b/packages/text-annotator/src/state/spatial-tree.ts
@@ -2,15 +2,12 @@ import RBush from 'rbush';
 import type { Store } from '@annotorious/core';
 import { createNanoEvents, type Unsubscribe } from 'nanoevents';
 import type { AnnotationRects } from '../state/text-annotation-store';
-import { mergeClientRects, getHighlightClientRects, toParentBounds } from '../utils/highlight'; 
-import { reviveTextSelector } from '../utils/annotation';
-import type { 
+import { mergeClientRects, getHighlightClientRects, toParentBounds } from '../utils/highlight';
+import type {
   RevivedTextAnnotationLike,
-  RevivedTextSelectorLike, 
-  TextAnnotationLike, 
-  TextAnnotationTarget, 
-  TextAnnotationTargetLike, 
-  TextSelector 
+  RevivedTextAnnotationTargetLike,
+  TextAnnotationLike,
+  TextAnnotationTargetLike
 } from '../model';
 
 interface IndexedHighlightRect {
@@ -43,8 +40,7 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
   store: Store<T>,
   container: HTMLElement,
   hMergeTolerance?: number,
-  vMergeTolerance?: number,
-  selectorReviveFn?: (arg: T['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike
+  vMergeTolerance?: number
 ) => {
 
   const tree = new RBush<IndexedHighlightRect>();
@@ -54,15 +50,8 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
   const emitter = createNanoEvents<SpatialTreeEvents>();
 
   // Helper: converts a single text annotation target to a list of hightlight rects
-  const toItems = (target: TextAnnotationTargetLike, offset: DOMRect): IndexedHighlightRect[] => {
-    const rects = target.selector.flatMap(s => {
-      const revivedRange = (selectorReviveFn 
-        ? selectorReviveFn(s, container) 
-        : reviveTextSelector(s as TextSelector, container)
-      )?.range;
-
-      return getHighlightClientRects(revivedRange);
-    });
+  const toItems = (target: RevivedTextAnnotationTargetLike, offset: DOMRect): IndexedHighlightRect[] => {
+    const rects = target.selector.flatMap(s => getHighlightClientRects(s.range));
 
     /**
      * Offset the merged client rects so that coords
@@ -94,7 +83,7 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
     index.clear();
   }
 
-  const insert = (target: TextAnnotationTargetLike) => {
+  const insert = (target: RevivedTextAnnotationTargetLike) => {
     const rects = toItems(target, container.getBoundingClientRect());
     if (rects.length === 0) return;
 
@@ -110,12 +99,12 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
     }
   }
 
-  const update = (target: TextAnnotationTargetLike) => {
+  const update = (target: RevivedTextAnnotationTargetLike) => {
     remove(target);
     insert(target);
   }
 
-  const set = (targets: TextAnnotationTargetLike[], replace: boolean = true) => {
+  const set = (targets: RevivedTextAnnotationTargetLike[], replace: boolean = true) => {
     if (replace)
       clear();
 
@@ -209,7 +198,7 @@ export const createSpatialTree = <T extends TextAnnotationLike>(
   const size = () => tree.all().length;
 
   const recalculate = () => {
-    set(store.all().map(a => a.target as TextAnnotationTarget), true);
+    set(store.all().map(a => a.target as RevivedTextAnnotationTargetLike), true);
     emitter.emit('recalculate');
   };
 

--- a/packages/text-annotator/src/state/text-annotator-state.ts
+++ b/packages/text-annotator/src/state/text-annotator-state.ts
@@ -12,7 +12,13 @@ import type {
   HoverState, 
 } from '@annotorious/core';
 import { isRevived } from '../model';
-import type { RevivedTextAnnotationLike, TextAnnotation, TextAnnotationLike, TextAnnotationTargetLike } from '../model';
+import type {
+  RevivedTextAnnotationLike,
+  RevivedTextAnnotationTargetLike,
+  TextAnnotation,
+  TextAnnotationLike,
+  TextAnnotationTargetLike
+} from '../model';
 import { createSpatialTree, type SpatialTreeEvents } from '../state/spatial-tree';
 import type { AnnotationRects, TextAnnotationStore } from '../state/text-annotation-store';
 import { reviveAnnotation, reviveTarget } from '../utils/annotation';
@@ -42,8 +48,7 @@ export const createTextAnnotatorState = <I extends TextAnnotationLike = TextAnno
     store,
     container,
     opts.mergeHighlights?.horizontalTolerance,
-    opts.mergeHighlights?.verticalTolerance,
-    opts.selectorReviveFn
+    opts.mergeHighlights?.verticalTolerance
   );
 
   const selection = createSelectionState<I, E>(store, opts.userSelectAction, opts.adapter);
@@ -151,10 +156,10 @@ export const createTextAnnotatorState = <I extends TextAnnotationLike = TextAnno
       deleted.forEach(a => tree.remove(a.target));
 
     if (created.length > 0)
-      tree.set(created.map(a => a.target), false);
+      tree.set(created.map(a => a.target as RevivedTextAnnotationTargetLike), false);
 
     if (updated?.length > 0)
-      updated.forEach(({ newValue }) => tree.update(newValue.target));
+      updated.forEach(({ newValue }) => tree.update(newValue.target as RevivedTextAnnotationTargetLike));
   });
 
   return {

--- a/packages/text-annotator/src/text-annotator-options.ts
+++ b/packages/text-annotator/src/text-annotator-options.ts
@@ -14,7 +14,7 @@ export interface TextAnnotatorOptions<I extends TextAnnotationLike = TextAnnotat
    * Custom function that turns a stored selector into a revived one (with a live DOM `range`).
    * Used by sub-formats such as PDF to map their selector shape to a text range.
    */
-  selectorReviveFn?: (arg: I['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike;
+  selectorReviveFn?: (arg: I['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike | RevivedTextSelectorLike[];
 
   /**
    * Determines whether an active selection should be dismissed

--- a/packages/text-annotator/src/utils/annotation/revive-annotation.ts
+++ b/packages/text-annotator/src/utils/annotation/revive-annotation.ts
@@ -86,17 +86,17 @@ export const reviveTextSelector = <T extends TextSelector>(
 export const reviveTarget = <T extends TextAnnotationTargetLike>(
   target: T, 
   container: HTMLElement,
-  reviveFn: (arg: T['selector'][number], container: HTMLElement) => RevivedTextSelectorLike =
-    (s, c) => reviveTextSelector(s as TextSelector, c) as RevivedTextSelectorLike
+  reviveFn: (arg: T['selector'][number], container: HTMLElement) => RevivedTextSelectorLike | RevivedTextSelectorLike[] =
+    (s, c) => reviveTextSelector(s as TextSelector, c)
 ): RevivedTextAnnotationTargetLike<T> => ({
   ...target,
-  selector: target.selector.map(s => reviveFn(s, container))
+  selector: target.selector.flatMap(s => reviveFn(s, container))
 });
 
 export const reviveAnnotation = <T extends TextAnnotationLike>(
   annotation: T, 
   container: HTMLElement,
-  reviveFn?: (arg: T['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike
+  reviveFn?: (arg: T['target']['selector'][number], container: HTMLElement) => RevivedTextSelectorLike | RevivedTextSelectorLike[]
 ): RevivedTextAnnotationLike<T> => ({ 
   ...annotation, 
   target: reviveTarget(annotation.target, container, reviveFn) 


### PR DESCRIPTION
## Issue

`selectorReviveFn` currently has to revive each stored selector into exactly one DOM range. However, in some consuming applications, there's a need to split that single selector into pieces based on the content.
The motivation and the original discussion are in https://github.com/annotorious/annotorious/pull/607#issuecomment-4680742386.

## Changes Made

- Widened the `selectorReviveFn` option signature to return `RevivedTextSelectorLike | RevivedTextSelectorLike[]`, so one stored selector can fan out into multiple revived selectors when needed.
- Updated `reviveTarget` / `reviveAnnotation` to splat the returned arrays via `.flatMap`, producing a flat list of revived selectors on the target.
- Refactored `spatial-tree.ts` so revival is no longer its concern:
  - `toItems` now reads `s.range` directly from already-revived selectors instead of re-running the revive function on every `insert` / `update` / `set` / `recalculate`. Beyond saving work, this sidesteps the old `(...)?.range` access that would have silently dropped array returns from a splitting `selectorReviveFn`.
  - `createSpatialTree` no longer takes a `selectorReviveFn` parameter — the tree is decoupled from the option's signature.
  - `insert`, `update`, and `set` are typed `RevivedTextAnnotationTargetLike`. `remove` stays on the permissive `TextAnnotationTargetLike` since it only uses `target.annotation` for index lookup and never reaches `toItems`.
- Updated the spatial tree's caller in `text-annotator-state.ts` accordingly. Revival continues to happen exactly once per write — upstream in `addAnnotation` / `syncAnnotations` / `bulkUpsertAnnotations` / `updateTarget` — before targets reach the tree.

###### Soomo Staged