### PR TITLE
Add `hideAnnotations` prop to React text/TEI annotators

### DIFF
--- a/packages/text-annotator-react/src/tei/tei-annotator.tsx
+++ b/packages/text-annotator-react/src/tei/tei-annotator.tsx
@@ -13,6 +13,8 @@ export type TEIAnnotatorProps = TextAnnotatorOptions<TEIAnnotation, unknown> & {
 
   filter?: Filter;
 
+  hideAnnotations?: boolean;
+
 }
 
 export const TEIAnnotator = (props: TEIAnnotatorProps) => {
@@ -29,6 +31,8 @@ export const TEIAnnotator = (props: TEIAnnotatorProps) => {
   useEffect(() => anno?.setStyle(props.style), [anno, props.style]);
 
   useEffect(() => anno?.setFilter(props.filter), [anno, props.filter]);
+
+  useEffect(() => anno?.setVisible(!props.hideAnnotations), [anno, props.hideAnnotations]);
 
   useEffect(() => anno?.setUser(opts.user), [anno, opts.user]);
 

--- a/packages/text-annotator-react/src/text-annotator.tsx
+++ b/packages/text-annotator-react/src/text-annotator.tsx
@@ -16,6 +16,8 @@ export interface TextAnnotatorProps<I extends TextAnnotation = TextAnnotation, E
 
   filter?: Filter<I>;
 
+  hideAnnotations?: boolean;
+
   className?: string;
 
 }
@@ -26,7 +28,7 @@ export const TextAnnotator = <I extends TextAnnotation = TextAnnotation, E exten
 
   const el = useRef<HTMLDivElement>(null);
 
-  const { className, children, ...opts } = props;
+  const { className, children, hideAnnotations, ...opts } = props;
 
   const { style, filter, user, annotatingEnabled, userSelectAction, annotatingMode } = opts;
 
@@ -46,6 +48,8 @@ export const TextAnnotator = <I extends TextAnnotation = TextAnnotation, E exten
   useEffect(() => anno?.setStyle(style), [anno, style]);
 
   useEffect(() => anno?.setFilter(filter), [anno, filter]);
+
+  useEffect(() => anno?.setVisible(!hideAnnotations), [anno, hideAnnotations]);
 
   useEffect(() => anno?.setUser(user), [anno, user]);
 


### PR DESCRIPTION
### In this PR

Per https://github.com/recogito/recogito-studio-sdk/pull/13#pullrequestreview-4513063408:
- Add `hideAnnotations` prop to React wrappers for text/TEI annotators, using `setVisible` on the annotator instance

### Questions

Is it ok that this will only work for now on the span renderer? It seems `setVisible` is defined there but not on the CSS highlight renderer.