### PR TITLE
Remove the scroll listener with the capture flag it was registered with

### DIFF
--- a/packages/text-annotator/src/rendering/base-renderer.ts
+++ b/packages/text-annotator/src/rendering/base-renderer.ts
@@ -229,7 +229,9 @@ export const createRenderer = <T extends TextAnnotatorState<TextAnnotationLike, 
     unsubscribeSelection();
     unsubscribeHover();
 
-    document.removeEventListener('scroll', onScroll);
+    // Note: the capture flag must match the one used on registration,
+    // otherwise this call matches no listener and silently does nothing.
+    document.removeEventListener('scroll', onScroll, { capture: true });
 
     // onResize.clear();
     window.removeEventListener('resize', onResize);

--- a/packages/text-annotator/test/rendering/base-renderer.test.ts
+++ b/packages/text-annotator/test/rendering/base-renderer.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRenderer, type Painter } from '../../src/rendering/base-renderer';
+
+/**
+ * The renderer redraws through a 10ms debounce and a rAF, so give both a
+ * chance to run before asserting.
+ */
+const flushRedraw = () => new Promise(resolve => setTimeout(resolve, 50));
+
+const createPainter = () => ({
+  destroy: vi.fn(),
+  redraw: vi.fn(),
+  setVisible: vi.fn()
+}) satisfies Painter;
+
+const createState = () => ({
+  store: {
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    getAt: vi.fn(),
+    getIntersecting: vi.fn(() => []),
+    recalculatePositions: vi.fn()
+  },
+  selection: {
+    subscribe: vi.fn(() => vi.fn()),
+    selected: [],
+    evalSelectAction: vi.fn()
+  },
+  hover: {
+    subscribe: vi.fn(() => vi.fn()),
+    current: undefined,
+    set: vi.fn()
+  }
+});
+
+const viewport = { set: vi.fn() };
+
+describe('createRenderer', () => {
+
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    // jsdom has no ResizeObserver.
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('should redraw when the page scrolls', async () => {
+    const painter = createPainter();
+    const renderer = createRenderer(painter, container, createState() as any, viewport as any);
+
+    container.dispatchEvent(new Event('scroll'));
+    await flushRedraw();
+
+    expect(painter.redraw).toHaveBeenCalled();
+
+    renderer.destroy();
+  });
+
+  it('should stop redrawing on scroll after destroy', async () => {
+    // Regression test: the scroll listener is registered with { capture: true },
+    // so destroy() has to remove it with the same flag. Without it the listener
+    // stays on the document forever, and every destroyed renderer keeps forcing
+    // a full redraw on every scroll event in the page.
+    const painter = createPainter();
+    const renderer = createRenderer(painter, container, createState() as any, viewport as any);
+
+    renderer.destroy();
+    painter.redraw.mockClear();
+
+    container.dispatchEvent(new Event('scroll'));
+    await flushRedraw();
+
+    expect(painter.redraw).not.toHaveBeenCalled();
+  });
+
+});


### PR DESCRIPTION
Fixes #283.

### The bug

`base-renderer.ts` registers its scroll listener in the capture phase but removes it without the flag:

```ts
// :191
document.addEventListener('scroll', onScroll, { capture: true, passive: true });

// :232 — before this PR
document.removeEventListener('scroll', onScroll);
```

`removeEventListener` only matches a registration whose capture flag is equal, so that call was a no-op: **every `destroy()`ed renderer left its scroll listener attached to the document.** Each orphan keeps calling `redraw(true)` — a forced, full highlight-layer rebuild — on every scroll event in the page, so the cost accumulates over a session with every mount/destroy cycle (collapsing a panel, re-creating an annotator, client-side route changes, several annotators on one page).

### The change

One line, plus a note so it does not regress:

```diff
-    document.removeEventListener('scroll', onScroll);
+    // Note: the capture flag must match the one used on registration,
+    // otherwise this call matches no listener and silently does nothing.
+    document.removeEventListener('scroll', onScroll, { capture: true });
```

### The test

`test/rendering/base-renderer.test.ts` drives `createRenderer` with a stub painter/state and asserts the observable behaviour rather than the listener bookkeeping:

- **control** — a scroll event *does* reach the painter while the renderer is mounted, so the harness is known to be live;
- **regression** — after `destroy()`, a scroll event must not reach the painter.

Verified in both directions: the regression test fails on `main` (`painter.redraw` is called once after `destroy()`) and passes with the fix. The control test passes either way.

`npx vitest run` in `packages/text-annotator` → 5 passed. `tsc -p tsconfig.build.json` clean. `package-lock.json` deliberately untouched.

### Not included

`onResize.clear()` is commented out two lines below (`base-renderer.ts:234`), so a resize debounced just before `destroy()` can still fire afterwards and run `store.recalculatePositions()` + `redraw()` against a destroyed painter. That one needs a `clear()` on the local `debounce` helper (the current implementation does not expose one), so it felt out of scope here — happy to follow up if you want it fixed too.
